### PR TITLE
Increasing lambda timeout

### DIFF
--- a/deployments/cdk/lib/cdk-stack.ts
+++ b/deployments/cdk/lib/cdk-stack.ts
@@ -54,6 +54,7 @@ export class CdkStack extends cdk.Stack {
       code: new lambda.AssetCode(props.lambdaPath),
       runtime: lambda.Runtime.GO_1_X,
       handler: 'ssosync',
+      timeout: cdk.Duration.seconds(30),
       environment: {
         "SSOSYNC_GOOGLE_CREDENTIALS": googleCredSecret.ref,
         "SSOSYNC_GOOGLE_TOKEN": googleTokenSecret.ref,


### PR DESCRIPTION
The default 3s is just not enough, even for a tiny organisation....

Alters the CDK deployment to set a 30s timeout for the lamba function in place of the default 3s. With an organisation including just 2 users and a few groups, the 3s timeout was being hit...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
