### PR TITLE
fix(retry): use go-retryablehttp to help withe http errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.33.7
 	github.com/golang/mock v1.4.3
 	github.com/golang/protobuf v1.4.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.7
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,11 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
+github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/internal/aws/client.go
+++ b/internal/aws/client.go
@@ -67,8 +67,8 @@ type client struct {
 }
 
 // NewClient creates a new client to talk with AWS SSO's SCIM endpoint. It
-// required a http.Client{} as well as the URL and bearer token from the
-/// console. If the URL is not parsable, an error will be thrown.
+// requires a http.Client{} as well as the URL and bearer token from the
+// console. If the URL is not parsable, an error will be thrown.
 func NewClient(c HttpClient, config *Config) (Client, error) {
 	u, err := url.Parse(config.Endpoint)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
Resolves #13 

*Description of changes:*
Adding go-retryablehttp to add retries to the aws scim http client with exponential back-off capabilities. This library also supports retrying 429 throttle responses. It is a drop in replacement for the standard `http.Client`. The retryablehttp module is also configurable although this pull request does not expose the config options.

The logging context is not completely connected. It is embedding the complete `printf()` log as `msg` in the ssosync tool package as `level: info`.

Example:
```
{"level":"info","msg":"[DEBUG] GET https://scim.aws-region-1.amazonaws.com/1234-1234-1234/scim/v2/Users?filter=userName+eq+%22user%40example.com%22","time":"2020-08-14T21:08:56Z"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
