### PR TITLE
feat(include-group): adding include-groups option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Flags:
   -h, --help                        help for ssosync
       --ignore-groups strings       ignores these groups
       --ignore-users strings        ignores these users
+      --include-groups strings      include only these groups
       --log-format string           log format (default "text")
       --log-level string            log level (default "warn")
   -v, --version                     version for ssosync

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,6 +154,7 @@ func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringVarP(&cfg.GoogleAdmin, "google-admin", "u", "", "Google Admin Email")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreUsers, "ignore-users", []string{}, "ignores these users")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreGroups, "ignore-groups", []string{}, "ignores these groups")
+	rootCmd.Flags().StringSliceVar(&cfg.IncludeGroups, "include-groups", []string{}, "include only these groups")
 }
 
 func logConfig(cfg *config.Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	IgnoreUsers []string `mapstructure:"ignore_users"`
 	// Ignore groups ...
 	IgnoreGroups []string `mapstructure:"ignore_groups"`
+	// Include groups ...
+	IncludeGroups []string `mapstructure:"include_groups"`
+
 }
 
 const (

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -152,7 +152,7 @@ func (s *syncGSuite) SyncGroups() error {
 	correlatedGroups := make(map[string]*aws.Group)
 
 	for _, g := range googleGroups {
-		if s.ignoreGroup(g.Email) {
+		if s.ignoreGroup(g.Email) || !s.includeGroup(g.Email) {
 			continue
 		}
 
@@ -289,6 +289,16 @@ func (s *syncGSuite) ignoreUser(name string) bool {
 
 func (s *syncGSuite) ignoreGroup(name string) bool {
 	for _, g := range s.cfg.IgnoreGroups {
+		if g == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *syncGSuite) includeGroup(name string) bool {
+	for _, g := range s.cfg.IncludeGroups {
 		if g == name {
 			return true
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the option to *only* include a specified groups to the sync operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
