### PR TITLE
improv: set NoEcho on sensitive params in template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -51,15 +51,19 @@ Parameters:
   GoogleCredentials:
     Type: String
     Description: Credentials to log into Google (content of credentials.json)
+    NoEcho: true
   GoogleAdminEmail:
     Type: String
     Description: Google Admin email
+    NoEcho: true
   SCIMEndpointUrl:
     Type: String
     Description: AWS SSO SCIM Endpoint Url
+    NoEcho: true
   SCIMEndpointAccessToken:
     Type: String
     Description: AWS SSO SCIM AccessToken
+    NoEcho: true
 
 Resources:
   SSOSyncFunction:


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

mask the parameter value to prevent it from being displayed in the console, command line tools, or API

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
