### PR TITLE
fix: limit iam policy only to the secret arns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         run: GOBIN=$PWD/bin go install honnef.co/go/tools/cmd/staticcheck && ./bin/staticcheck ./...
 
       - name: Run Linting
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.27
+          version: v1.33.0
 
       - name: Run Tests
         run: go test -cover -p 1 -race -v ./...

--- a/template.yaml
+++ b/template.yaml
@@ -82,7 +82,11 @@ Resources:
             Effect: Allow
             Action:
               - "secretsmanager:Get*"
-            Resource: '*'
+            Resource:
+              - !Ref AWSGoogleCredentialsSecret
+              - !Ref AWSGoogleAdminEamil
+              - !Ref AWSSCIMEndpointSecret
+              - !Ref AWSSCIMAccessTokenSecret
       Events:
         SyncScheduledEvent:
           Type: Schedule


### PR DESCRIPTION
*Issue #, if available:* - 

*Description of changes:*
Changing Function policy to limit access to the secrets we create.
Without this, the function has access to every secret, this policy should scope if to the proper resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
