### PR TITLE
feat: CLI option to support adding users from specific G-Suite group(s)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,6 +154,7 @@ func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringVarP(&cfg.GoogleAdmin, "google-admin", "u", "", "Google Admin Email")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreUsers, "ignore-users", []string{}, "ignores these users")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreGroups, "ignore-groups", []string{}, "ignores these groups")
+	rootCmd.Flags().StringSliceVar(&cfg.AddGroups, "add-groups", []string{}, "add these groups")
 }
 
 func logConfig(cfg *config.Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	IgnoreUsers []string `mapstructure:"ignore_users"`
 	// Ignore groups ...
 	IgnoreGroups []string `mapstructure:"ignore_groups"`
+	// Add groups ...
+	AddGroups []string `mapstructure:"add_groups"`
 }
 
 const (


### PR DESCRIPTION
*Issue #, if available:*
PRO-710

*Description of changes:*
There is an open source version of SSOSync framework on Github. The CLI exposes several options like --exclude-groups, --ignore-groups etc. This doesn't fit well Signavio's usecase where only a subset of groups would rather be synced over to AWS SSO. This pull request introduces a --add-groups option to only sync relevant groups from G-Suite -> AWS SSO, and ignore the rest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
