### PR TITLE
fix --ignore-groups flag to ignore group from google group

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -274,6 +274,15 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 	if err != nil {
 		return err
 	}
+	filteredGoogleGroups := []*admin.Group{}
+	for _, g := range googleGroups {
+		if s.ignoreGroup(g.Email) {
+			log.WithField("group", g.Email).Debug("ignoring group")
+			continue
+		}
+		filteredGoogleGroups = append(filteredGoogleGroups, g)
+	}
+	googleGroups = filteredGoogleGroups
 
 	log.Debug("get google users and groups and its users")
 	googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(googleGroups)


### PR DESCRIPTION
*Issue #, if available:*
The existing flow to ignore group is not working properly.
In detail:
`s.google.GetGroups` will return list of groups
`s.getGoogleGroupsAndUsers` will return the list of user from group which not filtered by flag `--ignore-groups`
up until this step is correct. next step will make it break.
`getGroupOperations` will return list of groups that need to be created in AWS SSO. This function do not have filter. It will cause the group that supposed to be ignored get created.


*Description of changes:*
The fix is to filter output of `s.google.GetGroups` by value from flag `--ignore-groups`
Therefore the remaining flow will have certainty that no ignored group get processed.

*Example*
Execution
```
go run main.go \
-t $SSO_TOKEN \
-d \
-e $SSO_ENDPOINT\
-u "me@purnaresa.co" \
-c credentials.json \
-g 'email:aws*' \
-s groups \
--ignore-groups="aws-admin@purnaresa.co,aws-test@purnaresa.co"
```
Output
```
INFO[0000] syncing                                       sync_method=groups
DEBU[0000] get google groups                             query="email:aws*"
DEBU[0000] ignoring group                                group=aws-admin@purnaresa.co
DEBU[0000] ignoring group                                group=aws-test@purnaresa.co
DEBU[0000] get google users and groups and its users    
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
