### PR TITLE
fix: Sync more then 50 users with sync-method groups

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -359,14 +359,18 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 	// add aws users (added in google)
 	log.Debug("creating aws users added in google")
 	for _, awsUser := range addAWSUsers {
+		// Due to limits in users listing, the user may already exists
+		// see https://docs.aws.amazon.com/singlesignon/latest/developerguide/listusers.html
+		user, _ := s.aws.FindUserByEmail(awsUser.Username)
+		if user == nil {
+			log := log.WithFields(log.Fields{"user": awsUser.Username})
 
-		log := log.WithFields(log.Fields{"user": awsUser.Username})
-
-		log.Info("creating user")
-		_, err := s.aws.CreateUser(awsUser)
-		if err != nil {
-			log.Error("error creating user")
-			return err
+			log.Info("creating user")
+			_, err := s.aws.CreateUser(awsUser)
+			if err != nil {
+				log.Error("error creating user")
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With more then 50 users in google and sync-method groups, the sync may fail when tries to create an user that already exists. The cause is the limits in user listing, see [AWS-SSO-list-users](https://docs.aws.amazon.com/singlesignon/latest/developerguide/listusers.html). This pr adds a workaround to solve this problem by validating if the user already exists in aws.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
