### PR TITLE
Google client err handling improvement

### DIFF
--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -42,11 +42,11 @@ func NewClient(ctx context.Context, adminEmail string, serviceAccountKey []byte)
 		admin.AdminDirectoryGroupMemberReadonlyScope,
 		admin.AdminDirectoryUserReadonlyScope)
 
-	config.Subject = adminEmail
-
 	if err != nil {
 		return nil, err
 	}
+
+	config.Subject = adminEmail
 
 	ts := config.TokenSource(ctx)
 


### PR DESCRIPTION
*Issue #56*

*Description of changes:*
Error:

`
[{"path":"github.com/aws/aws-lambda-go@v1.23.0/lambda/errors.go","line":39,"label":"lambdaPanicResponse"},{"path":"github.com/aws/aws-lambda-go@v1.23.0/lambda/function.go","line":36,"label":"(*Function).Invoke.func1"},{"path":"runtime/panic.go","line":965,"label":"gopanic"},{"path":"runtime/panic.go","line":212,"label":"panicmem"},{"path":"runtime/signal_unix.go","line":734,"label":"sigpanic"},{"path":"cfir/git/ssosync/internal/google/client.go","line":45,"label":"NewClient"},{"path":"cfir/git/ssosync/internal/sync.go","line":687,"label":"DoSync"},{"path":"cfir/git/ssosync/cmd/root.go","line":55,"label":"glob..func1"},{"path":"github.com/spf13/cobra@v1.1.3/command.go","line":852,"label":"(*Command).execute"},{"path":"github.com/spf13/cobra@v1.1.3/command.go","line":960,"label":"(*Command).ExecuteC"},{"path":"github.com/spf13/cobra@v1.1.3/command.go","line":897,"label":"(*Command).Execute"},{"path":"reflect/value.go","line":476,"label":"Value.call"},{"path":"reflect/value.go","line":337,"label":"Value.Call"},{"path":"github.com/aws/aws-lambda-go@v1.23.0/lambda/handler.go","line":124,"label":"NewHandler.func1"},{"path":"github.com/aws/aws-lambda-go@v1.23.0/lambda/handler.go","line":24,"label":"lambdaHandler.Invoke"},{"path":"github.com/aws/aws-lambda-go@v1.23.0/lambda/function.go","line":64,"label":"(*Function).Invoke"},{"path":"reflect/value.go","line":476,"label":"Value.call"},{"path":"reflect/value.go","line":337,"label":"Value.Call"},{"path":"net/rpc/server.go","line":377,"label":"(*service).call"},{"path":"runtime/asm_amd64.s","line":1371,"label":"goexit"}] END RequestId: ab43f97f-ab0f-4292-a001-53529de7b2fc REPORT RequestId: ab43f97f-ab0f-4292-a001-53529de7b2fc Duration: 1110.06 ms Billed Duration: 1111 ms Memory Size: 128 MB Max Memory Used: 53 MB Init Duration: 147.93 ms runtime error: invalid memory address or nil pointer dereference errorString 
`

https://github.com/awslabs/ssosync/blob/master/internal/google/client.go#L45-L49
This piece of code should be swapped, otherwise we will be mislead by the error message above and it will cover up the actual error which comes from `google.JWTConfigFromJSON`. If config is `null` then `config.Subject = adminEmail` would never work.
