### PR TITLE
Fix nested Google groups causing panic, fix adding users to groups immediately after creating AWS group

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -377,11 +377,12 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
 
 		log.Info("creating group")
-		_, err := s.aws.CreateGroup(awsGroup)
+		newGroup, err := s.aws.CreateGroup(awsGroup)
 		if err != nil {
 			log.Error("creating group")
 			return err
 		}
+		awsGroup.ID = newGroup.ID
 
 		// add members of the new group
 		for _, googleUser := range googleGroupsUsers[awsGroup.DisplayName] {

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -502,6 +502,10 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 				continue
 			}
 
+			if m.Type != "USER" {
+				continue
+			}
+
 			log.WithField("id", m.Email).Debug("get user")
 			q := fmt.Sprintf("email:%s", m.Email)
 			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Populate group ID after creation in addAWSGroups - group ID would not be populated, making the PATCH request for adding users to the AWS group fail.
2. Skip non-users when adding users to groups (skip nested groups) - would fail and stop prematurely previously, when attempting to GetUsers from Google for the nested group.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
