### PR TITLE
fix: A case where the user already exists but it tries to create again

### DIFF
--- a/internal/aws/client.go
+++ b/internal/aws/client.go
@@ -35,6 +35,14 @@ var (
 	ErrGroupNotSpecified = errors.New("group not specified")
 )
 
+type ErrHttpNotOK struct {
+	StatusCode int
+}
+
+func (e *ErrHttpNotOK) Error() string {
+	return fmt.Sprintf("status of http response was %d", e.StatusCode)
+}
+
 // OperationType handle patch operations for add/remove
 type OperationType string
 
@@ -122,7 +130,7 @@ func (c *client) sendRequestWithBody(method string, url string, body interface{}
 
 	// If we get a non-2xx status code, raise that via an error
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusNoContent {
-		err = fmt.Errorf("status of http response was %d", resp.StatusCode)
+		err = &ErrHttpNotOK{resp.StatusCode}
 	}
 
 	return

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -17,6 +17,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -365,6 +366,11 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 		log.Info("creating user")
 		_, err := s.aws.CreateUser(awsUser)
 		if err != nil {
+			errHttp := new(aws.ErrHttpNotOK)
+			if errors.As(err, &errHttp) && errHttp.StatusCode == 409 {
+				log.WithField("user", awsUser.Username).Warn("user already exists")
+				continue
+			}
 			log.Error("error creating user")
 			return err
 		}


### PR DESCRIPTION
Since AWS SSO SCIM only supports [fetching up to 50 users in the ListUsers request](https://docs.aws.amazon.com/singlesignon/latest/developerguide/listusers.html#not-supported-listusers), we must ignore the case when the API returns the HTTP Code 409 (Conflict), that indicated the resource already exists.

Fixes #65