### PR TITLE
fix: Ignore missing user in group members

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -507,6 +507,10 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 			if err != nil {
 				return nil, nil, err
 			}
+			if len(u) == 0 {
+				log.WithField("id", m.Email).Warn("missing user")
+				continue
+			}
 
 			membersUsers = append(membersUsers, u[0])
 


### PR DESCRIPTION
Closes #76 

Just ignores and alerts when a user listed as a member group doesn't exist.