### PR TITLE
Replaces extra `--s3-bucket` with `--s3-prefix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ RELEASER = goreleaser
 PACKAGED_TEMPLATE = packaged.yaml
 STACK_NAME := $(STACK_NAME)
 S3_BUCKET := $(S3_BUCKET)
+S3_PREFIX := $(S3_PREFIX)
 TEMPLATE = template.yaml
 APP_NAME ?= ssosync
 
@@ -44,7 +45,7 @@ publish:
 
 .PHONY: package
 package: build
-	sam package  --s3-bucket $(S3_BUCKET) --output-template-file $(PACKAGED_TEMPLATE) --s3-bucket $(S3_BUCKET)
+	sam package --s3-bucket $(S3_BUCKET) --output-template-file $(PACKAGED_TEMPLATE) --s3-prefix $(S3_PREFIX)
 
 .PHONY: deploy
 deploy: package


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

An additional `--s3-bucket` on the  package command is redundant.  There is no way to pass the s3 prefix to the package command.

Removes the extra `--s3-bucket` and instead replaces with `--s3-prefix`, passing in the environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
