### PR TITLE
Corrects the path to the ssosync executable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -115,7 +115,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Runtime: go1.x
-      Handler: dist/ssosync_linux_amd64_v1/ssosync
+      Handler: dist/ssosync_linux_amd64/ssosync
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The SAM template has `_v1` in the handler path.  Removes the `_v1` within the file path to match actual location of executable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
