### PR TITLE
Fix SyncGroupsUsers sync method group operations comments

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -569,7 +569,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 		googleMap[gGroup.Name] = struct{}{}
 	}
 
-	// AWS Groups found and not found in google
+	// Found Google groups which does not exist in AWS groups
 	for _, gGroup := range googleGroups {
 		if _, found := awsMap[gGroup.Name]; found {
 			equals = append(equals, awsMap[gGroup.Name])
@@ -578,7 +578,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 		}
 	}
 
-	// Google Groups founds and not in aws
+	// Found AWS groups which does not exist in Google groups
 	for _, awsGroup := range awsGroups {
 		if _, found := googleMap[awsGroup.DisplayName]; !found {
 			delete = append(delete, aws.NewGroup(awsGroup.DisplayName))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The comments that were fixed were actually inverse of what was happening.
1. The comment `AWS Groups found and not found in google`: In this case the code was finding groups that exists in google and not in AWS to add them to AWS.
2. The comment `Google Groups founds and not in aws`: In this case the code was finding groups that exists in AWS but not in google to delete them from AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
