### PR TITLE
Adds support for nested groups

### DIFF
--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -26,8 +26,10 @@ import (
 // Client is the Interface for the Client
 type Client interface {
 	GetUsers(string) ([]*admin.User, error)
+	GetUser(string) (*admin.User, error)
 	GetDeletedUsers() ([]*admin.User, error)
 	GetGroups(string) ([]*admin.Group, error)
+	GetGroup(string) (*admin.Group, error)
 	GetGroupMembers(*admin.Group) ([]*admin.Member, error)
 }
 
@@ -146,4 +148,30 @@ func (c *client) GetGroups(query string) ([]*admin.Group, error) {
 
 	}
 	return g, err
+}
+
+// GetGroup will get a single group from Google's Admin API
+// using the Method: groups.get with parameter "groupKey"
+// References:
+// * https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/get
+// groupKey possible values:
+//  group email address
+//  group alias
+//  unique group ID
+func (c *client) GetGroup(groupKey string) (*admin.Group, error) {
+	group, err := c.service.Groups.Get(groupKey).Context(context.TODO()).Do()
+	return group, err
+}
+
+// GetUser will get a single user from Google's Admin API
+// using the Method: users.get with parameter "userKey"
+// References:
+// * https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/get
+// userKey possible values:
+//  users primary email address
+//  alias email address
+//  unique user ID
+func (c *client) GetUser(userKey string) (*admin.User, error) {
+	user, err := c.service.Users.Get(userKey).Context(context.TODO()).Do()
+	return user, err
 }

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -17,7 +17,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/awslabs/ssosync/internal/aws"
@@ -468,6 +467,56 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 	return nil
 }
 
+// getAllGroupMembers return a slice of google group members of googleGroups
+// whereby all the members are of USER type and inherited groups are resolved.
+func (s *syncGSuite) getAllGroupMembers(group *admin.Group) ([]*admin.Member, error) {
+	members := make([]*admin.Member, 0)
+
+	groupMembers, err := s.google.GetGroupMembers(group)
+	if err != nil {
+		return nil, err
+	}
+
+	seenUsers := make(map[string]bool)
+
+	for _, m := range groupMembers {
+		switch m.Type {
+		case "GROUP":
+			// get group
+
+			nestedGroup, err := s.google.GetGroup(m.Id)
+			if err != nil {
+				return nil, err
+			}
+
+			log.WithFields(log.Fields{"group": nestedGroup.Name}).Debug("get group members from google")
+			additionalGroupMembers, err := s.getAllGroupMembers(nestedGroup)
+			if err != nil {
+				return nil, err
+			}
+
+			// Dedupe users by ID
+			for _, additionalMember := range additionalGroupMembers {
+				if _, exists := seenUsers[additionalMember.Id]; !exists {
+					members = append(members, additionalMember)
+					seenUsers[additionalMember.Id] = true
+				}
+			}
+
+		case "USER":
+			// Dedupe users by ID
+			if _, exists := seenUsers[m.Id]; !exists {
+				members = append(members, m)
+				seenUsers[m.Id] = true
+			}
+		default:
+			log.WithFields(log.Fields{"member_type": m.Type}).Warn("Unknown group member type")
+		}
+	}
+
+	return members, nil
+}
+
 // getGoogleGroupsAndUsers return a list of google users members of googleGroups
 // and a map of google groups and its users' list
 func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*admin.User, map[string][]*admin.User, error) {
@@ -486,7 +535,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 		}
 
 		log.Debug("get group members from google")
-		groupMembers, err := s.google.GetGroupMembers(g)
+		groupMembers, err := s.getAllGroupMembers(g)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -502,17 +551,16 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 			}
 
 			log.WithField("id", m.Email).Debug("get user")
-			q := fmt.Sprintf("email:%s", m.Email)
-			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)
+			u, err := s.google.GetUser(m.Id)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			membersUsers = append(membersUsers, u[0])
+			membersUsers = append(membersUsers, u)
 
 			_, ok := gUniqUsers[m.Email]
 			if !ok {
-				gUniqUsers[m.Email] = u[0]
+				gUniqUsers[m.Email] = u
 			}
 		}
 		gGroupsUsers[g.Name] = membersUsers


### PR DESCRIPTION
## Issues

Sorry didn't raise a specific issue but some exist:
Fixes #66
Fixes #51
Fixes #27

## Description

* Adds both `GetUser` and `GetGroup`
* Adds `getAllGroupMembers` - This resolves all users from a nested group hierarchy (if any) and de-duplicates users by their unique ID. This is called by `getGoogleGroupsAndUsers`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
