### PR TITLE
bug: Feature `group_match` in `user_groups` mode is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The function has `two behaviour` and these are controlled by the `--sync-method`
 
 Flags Notes:
 
-* `--include-groups` only works when `--sync-method` is `users_groups`
+* `--include-groups` only works when `--sync-method` is `users_groups`.  
 * `--ignore-users` works for both `--sync-method` values.  Example: `--ignore-users user1@example.com,user2@example.com` or `SSOSYNC_IGNORE_USERS=user1@example.com,user2@example.com`
 * `--ignore-groups` works for both `--sync-method` values. Example: --ignore-groups group1@example.com,group1@example.com` or `SSOSYNC_IGNORE_GROUPS=group1@example.com,group1@example.com`
 * `--group-match` works for both `--sync-method` values and also in combination with `--ignore-groups` and `--ignore-users`.  This is the filter query passed to the [Google Workspace Directory API when search Groups](https://developers.google.com/admin-sdk/directory/v1/guides/search-groups), if the flag is not used, groups are not filtered.
@@ -148,6 +148,12 @@ NOTES:
 
 1. Depending on the number of users and groups you have, maybe you can get `AWS SSO SCIM API rate limits errors`, and more frequently happens if you execute the sync many times in a short time.
 2. Depending on the number of users and groups you have, `--debug` flag generate too much logs lines in your AWS Lambda function.  So test it in locally with the `--debug` flag enabled and disable it when you use a AWS Lambda function.
+
+### Filtering Groups
+There are three stages to filtering groups that interact as follows:
+1. `--group-match/-g` is used to filter the selection set of the Google Admin API query.  If not supplied, all groups in the Google IAM directory will be returned
+2. `--include-groups` (if provided) will ensure only the groups that match are synced to AWS.  This parameter is optional and should be a comma-separated list of group email addresses `--include-groups abc@foo.bar,xyz@foo.bar`
+3. `--ignore-groups` can be used to further filter the results of the group query by ignoring specific groups, using a string match of the group's email address.
 
 ## AWS Lambda Usage
 

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -177,7 +177,7 @@ func (s *syncGSuite) SyncGroups(query string) error {
 
 	for _, g := range googleGroups {
 
-		if ShouldIncludeGroup(g.Email, s.cfg) {
+		if ! ShouldIncludeGroup(g.Email, s.cfg) {
 			continue
 		}
 

--- a/internal/sync_test.go
+++ b/internal/sync_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/ssosync/internal/aws"
+	"github.com/awslabs/ssosync/internal/config"
 	admin "google.golang.org/api/admin/directory/v1"
 )
 
@@ -347,6 +348,56 @@ func Test_getGroupUsersOperations(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotEquals, tt.wantEquals) {
 				t.Errorf("getGroupUsersOperations() gotEquals = %s, want %s", toJSON(gotEquals), toJSON(tt.wantEquals))
+			}
+		})
+	}
+}
+
+func Test_StringInSlice(t *testing.T) {
+	cases := []struct {
+		name string
+		slice []string
+		value string
+		result bool
+		} {
+			{ name: "no param no match", slice: []string{}, value: "foo", result:false, },
+			{ name: "no match", slice: []string{"bar"}, value: "foo", result: false},
+			{ name: "positive match", slice: []string{"bar","foo"}, value: "foo", result: true},
+			}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := StringInSlice (tc.slice, tc.value)
+			if (r != tc.result) {
+				t.Fatalf("%s fails", tc.name)
+			}
+		})
+	}
+}
+
+func Test_ShouldIncludeGroup(t *testing.T) {
+	cases := []struct {
+		name string
+		ignore []string
+		include []string
+		result bool
+	} {
+		{name: "neither", ignore: []string{}, include: []string{}, result: true},
+		{name: "include", ignore: []string{}, include: []string{"group","no"}, result: true},
+		{name: "include other", ignore: []string{}, include: []string{"no"}, result: false},
+		{name: "ignore", ignore: []string{"no","group"}, include: []string{}, result: false},
+		{name: "ignore other", ignore: []string{"no","nope"}, include: []string{}, result: true},
+		{name: "include precedence", ignore: []string{"group"}, include: []string{"group"}, result: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				IncludeGroups: tc.include,
+				IgnoreGroups: tc.ignore,
+			}
+			r := ShouldIncludeGroup("group",cfg)
+			if (r != tc.result) {
+				t.Fatalf("%s fails", tc.name)
 			}
 		})
 	}


### PR DESCRIPTION
*Issue #, if available:* #52, #53, referenced in #91

*Description of changes:*
I have specified what I believe to be the intentions of interactions between `group-match`,`ignore-groups` and `include-groups` in the documentation and unit test cases.  I also manually tested the different combinations and they worked as I would have expected.  We would have to (should?) do some further refactoring to build comprehensive unit test cases for how the config options map to behavior.

* Current Behavior:*
`ssosync -s users_groups -g 'name:foo*'` synchs all users but doesn't synch any groups despite the Google query matching and returning groups.  This is because logic in above line is always returning true as written.

*Expected Behavior:*
Above should now synchronize all groups that match.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
