### PR TITLE
#88: add delete protections

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -162,6 +162,7 @@ func configLambda() {
 func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.PersistentFlags().StringVarP(&cfg.GoogleCredentials, "google-admin", "a", config.DefaultGoogleCredentials, "path to find credentials file for Google Workspace")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Debug, "debug", "d", config.DefaultDebug, "enable verbose / debug logging")
+	rootCmd.PersistentFlags().BoolVarP(&cfg.Delete, "delete", "", config.DefaultDelete, "delete users and groups on AWS")
 	rootCmd.PersistentFlags().StringVarP(&cfg.LogFormat, "log-format", "", config.DefaultLogFormat, "log format")
 	rootCmd.PersistentFlags().StringVarP(&cfg.LogLevel, "log-level", "", config.DefaultLogLevel, "log level")
 	rootCmd.Flags().StringVarP(&cfg.SCIMAccessToken, "access-token", "t", "", "AWS SSO SCIM API Access Token")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ package config
 type Config struct {
 	// Verbose toggles the verbosity
 	Debug bool
+	// Delete is whether to delete on AWS
+	Delete bool
 	// LogLevel is the level with with to log for this config
 	LogLevel string `mapstructure:"log_level"`
 	// LogFormat is the format that is used for logging
@@ -44,12 +46,15 @@ const (
 	DefaultGoogleCredentials = "credentials.json"
 	// DefaultSyncMethod is the default sync method to use.
 	DefaultSyncMethod = "groups"
+	// DefaultDelete is whether to delete users and groups from AWS
+	DefaultDelete = false
 )
 
 // New returns a new Config
 func New() *Config {
 	return &Config{
 		Debug:             DefaultDebug,
+		Delete:            DefaultDelete,
 		LogLevel:          DefaultLogLevel,
 		LogFormat:         DefaultLogFormat,
 		SyncMethod:        DefaultSyncMethod,


### PR DESCRIPTION
*Issue #88*

*Description of changes:*

This PR provides two protections against inadvertent deletions:

1. `--delete` is now required to delete users and groups. (A single flag controls both behaviors.)
2. Groups with a name beginning "AWS" will never be deleted because they likely correspond to Control Tower administrative groups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
