### PR TITLE
Ignore missing user in group members

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -561,6 +561,10 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 			if err != nil {
 				return nil, nil, err
 			}
+			if len(u) == 0 {
+				log.WithField("id", m.Email).Warn("missing user")
+				continue
+			}
 
 			membersUsers = append(membersUsers, u[0])
 


### PR DESCRIPTION
*Issue #, if available:* #76

*Description of changes:*

Content of commit [f570818](https://github.com/awslabs/ssosync/commit/f57081807907ab16aed2703e5191db8fb35a3d78) introduced in PR #78 was accidentally overwritten by the huge commit [b4352b9](https://github.com/awslabs/ssosync/commit/b4352b919996c0dfd4fad03c0e7a8000e5fd5f88) on master. The bug described in #76 where missing user would cause `groups` sync method to crash therefore reappeared. This PR re-introduces the fix.

Thanks @ChrisPates for maintaining this cool repo 😎
