### PR TITLE
Make the Lambda timeout setting user configurable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,7 @@ Metadata:
           - IgnoreUsers
           - IgnoreGroups
           - IncludeGroups
+          - Timeout
 
   AWS::ServerlessRepo::Application:
     Name: ssosync
@@ -116,7 +117,12 @@ Parameters:
     AllowedValues:
       - groups
       - users_groups
-
+  Timeout:
+    Type: Number
+    Description: Timeout for the Lambda function
+    Default: 300
+    MinValue: 0
+    MaxValue: 900
 
 
 
@@ -126,7 +132,7 @@ Resources:
     Properties:
       Runtime: go1.x
       Handler: dist/ssosync_linux_amd64_v1/ssosync
-      Timeout: 300
+      Timeout: !Ref Timeout
       Environment:
         Variables:
           SSOSYNC_LOG_LEVEL: !Ref LogLevel


### PR DESCRIPTION
*Issue #, if available:* A quick and easy workaround for those experiencing #17

*Description of changes:*

Allow the Timeout value of the Lambda function to be modified via the SAM Application/CloudFormation template. We've recently sailed past the default 5 minute limit, and this change would make our IaC simpler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
