### PR TITLE
Add identityStore:DeleteGroup IAM permission

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -170,6 +170,7 @@ Resources:
                 - "identitystore:IsMemberInGroups"
                 - "identitystore:GetGroupMembershipId"
                 - "identitystore:DeleteGroupMembership"
+                - "identitystore:DeleteGroup"
               Resource:
                 - "*"
       Events:


### PR DESCRIPTION
Add identityStore:DeleteGroup IAM permission

This action is performed during the sync:
https://github.com/awslabs/ssosync/blob/955e8e23a42340d323e25659c8c03130b5609c80/internal/sync.go#L511

But the template does not give the IAM role permission to delete groups:
https://github.com/awslabs/ssosync/blob/b4352b919996c0dfd4fad03c0e7a8000e5fd5f88/template.yaml#L164

Resolves #116.