### PR TITLE
Add missing environment variable  to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can use the AWS Serverless Application Model (SAM) to deploy this to your ac
 
 > Please, install the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [GoReleaser](https://goreleaser.com/install/).
 
-Specify an Amazon S3 Bucket for the upload with `export S3_BUCKET=<YOUR_BUCKET>`.
+Specify an Amazon S3 Bucket for the upload with `export S3_BUCKET=<YOUR_BUCKET>` and an S3 prefix with `export S3_PREFIX=<YOUR_PREFIX>`.
 
 Execute `make package` in the console. Which will package and upload the function to the bucket. You can then use the `packaged.yaml` to configure and deploy the stack in [AWS CloudFormation Console](https://console.aws.amazon.com/cloudformation).
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Users need to define also the `S3_PREFIX` variable if they want to upload the files with `make package`. 
Add this missing information to README.md.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
