### PR TITLE
feat: sync-method groups filter by include groups as well

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -298,9 +298,21 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 			log.WithField("group", g.Email).Debug("ignoring group")
 			continue
 		}
+
+		if !s.includeGroup(g.Email) {
+			log.WithField("group", g.Email).Debug("ignoring group")
+			continue
+		}
 		filteredGoogleGroups = append(filteredGoogleGroups, g)
 	}
 	googleGroups = filteredGoogleGroups
+
+	var filteredQuery []string
+	for _, g := range googleGroups {
+		filteredQuery = append(filteredQuery, g.Name)
+	}
+	log.WithField("filtered-query", strings.Join(filteredQuery, ",")).Info("get google groups")
+
 
 	log.Debug("preparing list of google users and then google groups and their members")
 	googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(googleGroups)


### PR DESCRIPTION
*Description of changes:*

In this commit we extend the SyncUsersGroups method to filter groups using the --include-groups flag.

A group is included only if the e-mail elements of the include-groups flag match the e-mail elements of google groups.

The filtering is done after the ignoreGroup method is executed. This way we ensure that ignore takes
priority.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
