### PR TITLE
Add caching to avoid duplicate user fetches

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -561,6 +561,13 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 				continue
 			}
 
+			_, ok := gUniqUsers[m.Email]
+			if ok {
+				log.WithField("id", m.Email).Debug("get user skipped, already cached")
+				membersUsers = append(membersUsers, gUniqUsers[m.Email])
+				continue
+			}
+
 			log.WithField("id", m.Email).Debug("get user")
 			q := fmt.Sprintf("email:%s", m.Email)
 			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)
@@ -575,7 +582,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 
 			membersUsers = append(membersUsers, u[0])
 
-			_, ok := gUniqUsers[m.Email]
+			_, ok = gUniqUsers[m.Email]
 			if !ok {
 				gUniqUsers[m.Email] = u[0]
 			}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

At present, the `getGoogleGroupsAndUsers` function iterates over each group, then over each user, fetching each user sequentially from Google.

As a user can be part of multiple groups, we can minimise the number of calls to Google and improve performance. 
Using the existing `gUniqUsers` map, we can check if an entry for the user was added in a previous group iteration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
