### PR TITLE
feat: migrate from deprecated go1.x to provided.al2 and use arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test:
 go-build:
 	go build -o $(APP_NAME) main.go
 
+build-SSOSyncFunction:
+	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
+	cp ./bootstrap $(ARTIFACTS_DIR)/.
+
 .PHONY: clean
 clean:
 	rm -f $(OUTPUT) $(PACKAGED_TEMPLATE)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,7 +136,7 @@ func Handler(ctx context.Context, event events.CodePipelineEvent) (string, error
 func init() {
 	// init config
 	cfg = config.New()
-	cfg.IsLambda = len(os.Getenv("_LAMBDA_SERVER_PORT")) > 0
+	cfg.IsLambda = len(os.Getenv("AWS_LAMBDA_FUNCTION_NAME")) > 0
 
 	// initialize cobra
 	cobra.OnInitialize(initConfig)

--- a/template.yaml
+++ b/template.yaml
@@ -129,8 +129,10 @@ Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: go1.x
-      Handler: dist/ssosync_linux_amd64_v1/ssosync
+      Runtime: provided.al2
+      Handler: bootstrap
+      Architectures:
+        - arm64
       Timeout: 300
       Environment:
         Variables:
@@ -185,6 +187,8 @@ Resources:
           Properties:
             Enabled: true
             Schedule: !Ref ScheduleExpression
+    Metadata:
+      BuildMethod: makefile
 
   AWSGoogleCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"


### PR DESCRIPTION
*Issue #, if available:*
The go1.x runtime for AWS Lambda is deprecated an should reach EOL at 31.12.2023, see [this](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) post. The runtime to be used instead is `provided.al2`.
Migration description for SAM is provided [here](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/).

*Description of changes:*
* AWS Lambda runtime is changed from `go1.x` to `provided.al2`
* AWS Lambda architecture is changed from `amd64` to `arm64`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
