### PR TITLE
Change NoValue psuedo-parameters to references

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -533,7 +533,7 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: CreateFunction
     Properties:
-      FunctionName: !If [SetFunctionName, !Ref FunctionName, AWS::NoValue]
+      FunctionName: !If [SetFunctionName, !Ref FunctionName, !Ref AWS::NoValue]
       Role: !If [RemoteSecrets, !GetAtt SSOSyncRoleRemote.Arn, !GetAtt SSOSyncRoleLocal.Arn]
       Runtime: provided.al2
       Handler: bootstrap
@@ -550,12 +550,12 @@ Resources:
           SSOSYNC_SCIM_ACCESS_TOKEN: !If [CreateSecrets, !Ref SecretSCIMAccessToken, !Select [3, !Split [',', !Ref CrossStackConfig]]]
           SSOSYNC_REGION: !If [CreateSecrets, !Ref SecretRegion, !Select [4, !Split [',', !Ref CrossStackConfig]]]
           SSOSYNC_IDENTITY_STORE_ID: !If [CreateSecrets, !Ref SecretIdentityStoreID, !Select [5, !Split [',', !Ref CrossStackConfig]]]
-          SSOSYNC_USER_MATCH: !If [SetGoogleUserMatch, !Ref GoogleUserMatch, AWS::NoValue]
-          SSOSYNC_GROUP_MATCH: !If [SetGoogleGroupMatch, !Ref GoogleGroupMatch, AWS::NoValue]
+          SSOSYNC_USER_MATCH: !If [SetGoogleUserMatch, !Ref GoogleUserMatch, !Ref AWS::NoValue]
+          SSOSYNC_GROUP_MATCH: !If [SetGoogleGroupMatch, !Ref GoogleGroupMatch, !Ref AWS::NoValue]
           SSOSYNC_SYNC_METHOD: !Ref SyncMethod
-          SSOSYNC_IGNORE_GROUPS: !If [SetIgnoreGroups, !Ref IgnoreGroups, AWS::NoValue]
-          SSOSYNC_IGNORE_USERS: !If [SetIgnoreUsers, !Ref IgnoreUsers, AWS::NoValue]
-          SSOSYNC_INCLUDE_GROUPS: !If [SetIncludeGroups, !Ref IncludeGroups, AWS::NoValue]
+          SSOSYNC_IGNORE_GROUPS: !If [SetIgnoreGroups, !Ref IgnoreGroups, !Ref AWS::NoValue]
+          SSOSYNC_IGNORE_USERS: !If [SetIgnoreUsers, !Ref IgnoreUsers, !Ref AWS::NoValue]
+          SSOSYNC_INCLUDE_GROUPS: !If [SetIncludeGroups, !Ref IncludeGroups, !Ref AWS::NoValue]
       Events:
         SyncScheduledEvent:
           Type: Schedule


### PR DESCRIPTION
*Description of changes:*

This changes the instances of the [NoValue pseudo-parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html) to use the [Ref intrinsic function](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html), so that the key is omitted instead of the literal string `AWS::NoValue` being used.

Without this change, attempting to deploy the stack without a specified FunctionName results in an error:

```
Resource handler returned message: "1 validation error detected: Value 'AWS::NoValue' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_\.]+)(:(\$LATEST|[a-zA-Z0-9-_]+))? (Service: Lambda, Status Code: 400, Request ID: UUID)" (RequestToken: UUID, HandlerErrorCode: GeneralServiceException)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
