### PR TITLE
Escape hyphens in user/group character classes

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -177,35 +177,35 @@ Parameters:
     Description: |
       [optional] Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
     Default: ""
-    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
+    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.\-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.\-_]{1,64})@([a-zA-Z0-9.\-]{5,260}))'
 
   GoogleGroupMatch:
     Type: String
     Description: |
       [optional] Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
     Default: 'name:AWS*'
-    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
+    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.\-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.\-_]{1,64})@([a-zA-Z0-9.\-]{5,260}))'
 
   IgnoreGroups:
     Type: String
     Description: |
       [optional] Ignore these Google Workspace groups, leave empty if not required
     Default: ""
-    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z\-= _]*)(,[0-9a-zA-Z\-=@. _]*)*'
 
   IgnoreUsers:
     Type: String
     Description: |
       [optional] Ignore these Google Workspace users, leave empty if not required
     Default: ""
-    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z\-= _]*)(,[0-9a-zA-Z\-=@. _]*)*'
 
   IncludeGroups:
     Type: String
     Description: |
       [optional] Include only these Google Workspace groups, leave empty if not required. (Only applicable for SyncMethod user_groups)
     Default: ""
-    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z\-= _]*)(,[0-9a-zA-Z\-=@. _]*)*'
 
   SyncMethod:
     Type: String


### PR DESCRIPTION
*Issue #, if available:* #162

*Description of changes:*
Added an escape to the character class usage of the hyphen character in the CloudFormation template. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
