### PR TITLE
Add BuildMethod to SAM template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -563,7 +563,8 @@ Resources:
           Properties:
             Enabled: !If [OnSchedule, false, true]
             Schedule: !If [OnSchedule, !Ref ScheduleExpression, "rate(15 minutes)"]
-
+    Metadata:
+      BuildMethod: makefile
 
   KeyAlias:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
*Issue #, if available:* N/A.

We were getting this error when trying to run the Lambda function:

> Error: Couldn't find valid bootstrap(s): [/var/task/bootstrap /opt/bootstrap] Runtime.InvalidEntrypoint

*Description of changes:*

Add the `Metadata.BuildMethod` property to the Lamdba function as described [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/building-custom-runtimes.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
