### PR TITLE
Fix fetching binary secrets

### DIFF
--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/base64"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
@@ -81,16 +80,8 @@ func (s *Secrets) getSecret(secretKey string) (string, error) {
 	if r.SecretString != nil {
 		secretString = *r.SecretString
 	} else {
-		decodedBinarySecretBytes := make([]byte, base64.StdEncoding.DecodedLen(len(r.SecretBinary)))
-		l, err := base64.StdEncoding.Decode(decodedBinarySecretBytes, r.SecretBinary)
-		if err != nil {
-			return "", err
-		}
-		secretString = string(decodedBinarySecretBytes[:l])
+		secretString = string(r.SecretBinary)
 	}
 
 	return secretString, nil
 }
-
-
-


### PR DESCRIPTION
I'd originally opened https://github.com/awslabs/ssosync/pull/131 as a bugfix PR, but then deleted my fork which closed the PR without me realising 😅 

The [SDK already decodes from base64 automatically](https://github.com/aws/aws-sdk-go/blob/main/service/secretsmanager/api.go#L4350) so this was attempting to decode again, which fails with the below error:
```
{"level":"fatal","msg":"cannot read config: illegal base64 data at input byte 0","time":"2023-05-02T08:04:04Z"} 
```

It looks like the SAM template uses only string secrets so I'm not sure many people would've hit this branch of logic, but we added one of the secrets as binary and SSOSync stopped working.

Resolves https://github.com/awslabs/ssosync/issues/130

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
