### PR TITLE
200 name handling

### DIFF
--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -33,6 +33,15 @@ func NewUser(firstName string, lastName string, email string, active bool) *User
 		Type: "work",
 	})
 
+	// This handles the rare occation where these field are populated with a zero width space
+	// IAM Identity Center will reject.
+	if firstName == "​" {
+	        firstName = " "
+        }
+	if lastName == "​" {
+	        lastName = ""
+        }
+
 	return &User{
 		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		Username: email,

--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -35,11 +35,11 @@ func NewUser(firstName string, lastName string, email string, active bool) *User
 
 	// This handles the rare occation where these field are populated with a zero width space
 	// IAM Identity Center will reject.
-	if firstName == '​' {
+	if firstName == string('​') {
 	        firstName = " "
         }
-	if lastName == '​' {
-	        lastName = ""
+	if lastName == string('​') {
+	        lastName = " "
         }
 
 	return &User{

--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -65,14 +65,6 @@ func UpdateUser(id string, firstName string, lastName string, email string, acti
 		Type: "work",
 	})
 
-	// Work around for mononym
-	if lastName == "" {
-		lastName = " "
-	}
-	if firstName == "" {
-	 	firstName = " "
-	}
-
 	return &User{
 		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		ID:       id,

--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -33,15 +33,6 @@ func NewUser(firstName string, lastName string, email string, active bool) *User
 		Type: "work",
 	})
 
-	// This handles the rare occation where these field are populated with a zero width space
-	// IAM Identity Center will reject.
-	if firstName == string('​') {
-	        firstName = " "
-        }
-	if lastName == string('​') {
-	        lastName = " "
-        }
-
 	return &User{
 		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		Username: email,

--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -65,6 +65,14 @@ func UpdateUser(id string, firstName string, lastName string, email string, acti
 		Type: "work",
 	})
 
+	// Work around for mononym
+	if lastName == "" {
+		lastName = " "
+	}
+	if firstName == "" {
+	 	firstName = " "
+	}
+
 	return &User{
 		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		ID:       id,

--- a/internal/aws/users.go
+++ b/internal/aws/users.go
@@ -35,10 +35,10 @@ func NewUser(firstName string, lastName string, email string, active bool) *User
 
 	// This handles the rare occation where these field are populated with a zero width space
 	// IAM Identity Center will reject.
-	if firstName == "​" {
+	if firstName == '​' {
 	        firstName = " "
         }
-	if lastName == "​" {
+	if lastName == '​' {
 	        lastName = ""
         }
 

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -134,12 +134,8 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// Identity Store will accept and a 'space' for an empty name but not a 'zero width space'
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
-		if user.Name.GivenName == string("\u200B") {
-               		user.Name.GivenName = " "
-        	}
-        	if user.Name.FamilyName == string("\u200B") {
-                	user.Name.FamilyName = " "
-        	}
+		strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
+        	strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
 	}
 
 	// Check we've got some users otherwise something is wrong.

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -134,13 +134,7 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
 		user.Name.GivenName = strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
-		//if len(user.Name.GivenName) == 0 {
-		//	user.Name.GivenName = " "
-		//}
         	user.Name.FamilyName = strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
-		//if len(user.Name.FamilyName) == 0 {
-		//	user.Name.FamilyName = " "
-		//}
 	}
 
 	// Check we've got some users otherwise something is wrong.

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -135,7 +135,13 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
 		user.Name.GivenName = strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
+		if len(user.Name.GivenName) == 0 {
+			user.Name.GivenName = " "
+		}
         	user.Name.FamilyName = strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
+		if len(user.Name.FamilyName) == 0 {
+			user.Name.FamilyName = " "
+		}
 	}
 
 	// Check we've got some users otherwise something is wrong.

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -134,10 +134,10 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// Identity Store will accept and a 'space' for an empty name but not a 'zero width space'
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
-		if user.Name.GivenName == string("\u200b") {
+		if user.Name.GivenName == string("\u200B") {
                		user.Name.GivenName = " "
         	}
-        	if user.Name.FamilyName == string("\u200b") {
+        	if user.Name.FamilyName == string("\u200B") {
                 	user.Name.FamilyName = " "
         	}
 	}

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -113,7 +113,6 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
                         u = append(u, users.Users...)
                         return nil
                 })
-		return u, err
         } else {
 
 	        // The Google api doesn't support multi-part queries, but we do so we need to split into an array of query strings
@@ -135,13 +134,13 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
 		user.Name.GivenName = strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
-		if len(user.Name.GivenName) == 0 {
-			user.Name.GivenName = " "
-		}
+		//if len(user.Name.GivenName) == 0 {
+		//	user.Name.GivenName = " "
+		//}
         	user.Name.FamilyName = strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
-		if len(user.Name.FamilyName) == 0 {
-			user.Name.FamilyName = " "
-		}
+		//if len(user.Name.FamilyName) == 0 {
+		//	user.Name.FamilyName = " "
+		//}
 	}
 
 	// Check we've got some users otherwise something is wrong.

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -128,6 +128,20 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 		}
 	}
 
+	// some people prefer to go by a mononym
+	// Google directory will accept a 'zero width space' for an empty name but will not accept a 'space'
+	// but
+	// Identity Store will accept and a 'space' for an empty name but not a 'zero width space'
+	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
+	for _, user := range u {
+		if user.Name.GivenName == string('<200b>') {
+               		user.Name.GivenName = " "
+        	}
+        	if user.Name.FamilyName == string('<200b>') {
+                	user.Name.FamilyName = " "
+        	}
+	}
+
 	// Check we've got some users otherwise something is wrong.
         if len(u) == 0 {
                 return u, errors.New("google api returned 0 users?")

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -134,8 +134,8 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// Identity Store will accept and a 'space' for an empty name but not a 'zero width space'
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
-		strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
-        	strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
+		user.Name.GivenName = strings.Replace(user.Name.GivenName, string('\u200B'), " ", -1)
+        	user.Name.FamilyName = strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
 	}
 
 	// Check we've got some users otherwise something is wrong.

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -134,10 +134,10 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	// Identity Store will accept and a 'space' for an empty name but not a 'zero width space'
 	// So we need to replace any 'zero width space' strings with a single 'space' to allow comparison and sync
 	for _, user := range u {
-		if user.Name.GivenName == string('<200b>') {
+		if user.Name.GivenName == string("\u200b") {
                		user.Name.GivenName = " "
         	}
-        	if user.Name.FamilyName == string('<200b>') {
+        	if user.Name.FamilyName == string("\u200b") {
                 	user.Name.FamilyName = " "
         	}
 	}

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -294,6 +294,8 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 	if err != nil {
 		return err
 	}
+	log.WithField("googleGroups", gioogleGroups).Debug("Groups to sync")
+	log.WithField("googleUsers", googleUsers).Debug("Users to sync")
 
 	log.Info("get existing aws groups")
 	awsGroups, err := s.GetGroups()

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -640,9 +640,11 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 
 	// AWS Groups found and not found in google
 	for _, gGroup := range googleGroups {
-		if _, found := awsMap[gGroup.Name]; found {
+		if _, found := awsMap[gGroup.Name]; found {	
+		 	log.WithField("gGroup", gGroup).Debug("equals")
 			equals = append(equals, awsMap[gGroup.Name])
 		} else {
+		 	log.WithField("gGroup", gGroup).Debug("add")
 			add = append(add, aws.NewGroup(gGroup.Name))
 		}
 	}
@@ -650,6 +652,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 	// Google Groups founds and not in aws
 	for _, awsGroup := range awsGroups {
 		if _, found := googleMap[awsGroup.DisplayName]; !found {
+		 	log.WithField("awsGroup", awsGroup).Debug("delete")
 			delete = append(delete, aws.NewGroup(awsGroup.DisplayName))
 		}
 	}
@@ -677,15 +680,16 @@ func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*
 			if awsUser.Active == gUser.Suspended ||
 				awsUser.Name.GivenName != gUser.Name.GivenName ||
 				awsUser.Name.FamilyName != gUser.Name.FamilyName {
-				log.WithField("user", gUser).Debug("update")
+				log.WithField("gUser", gUser).Debug("update")
+				log.WithField("awsUser", awsUser).Debug("update")
 				update = append(update, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 
 			} else {
-			        log.WithField("user", awsUser).Debug("equals")
+			        log.WithField("awsUser", awsUser).Debug("equals")
 				equals = append(equals, awsUser)
 			}
 		} else {
-		        log.WithField("user", gUser).Debug("add")
+		        log.WithField("gUser", gUser).Debug("add")
 			add = append(add, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 		}
 	}
@@ -693,6 +697,7 @@ func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*
 	// Google Users founds and not in aws
 	for _, awsUser := range awsUsers {
 		if _, found := googleMap[awsUser.Username]; !found {
+			log.WithField("awsUser", awsUser).Debug("delete")
 			delete = append(delete, aws.NewUser(awsUser.Name.GivenName, awsUser.Name.FamilyName, awsUser.Username, awsUser.Active))
 		}
 	}

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -677,11 +677,15 @@ func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*
 			if awsUser.Active == gUser.Suspended ||
 				awsUser.Name.GivenName != gUser.Name.GivenName ||
 				awsUser.Name.FamilyName != gUser.Name.FamilyName {
+				log.WithField("user", gUser).Debug("update")
 				update = append(update, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
+
 			} else {
+			        log.WithField("user", awsUser).Debug("equals")
 				equals = append(equals, awsUser)
 			}
 		} else {
+		        log.WithField("user", gUser).Debug("add")
 			add = append(add, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 		}
 	}

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -533,6 +533,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
                 return nil, nil, nil, err
         }
         for _, u := range googleUsers {
+		log.WithField("email", u).Debug("processing member of gUserDetailCache")
                 gUserDetailCache[u.PrimaryEmail] = u
         }
 
@@ -554,7 +555,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
 
         log.Debug("process users from google, filtering as required")
 	for _, u := range googleUsers {
-		log.WithField("email", u.PrimaryEmail).Debug("processing member")
+		log.WithField("email", u).Debug("processing userMatch")
 
                 // Remove any users that should be ignored
 		if s.ignoreUser(u.PrimaryEmail) {

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -629,6 +629,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
 // getGroupOperations returns the groups of AWS that must be added, deleted and are equals
 func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (add []*aws.Group, delete []*aws.Group, equals []*aws.Group) {
 
+ 	log.Debug('getGroupOperations()')
 	awsMap := make(map[string]*aws.Group)
 	googleMap := make(map[string]struct{})
 
@@ -665,6 +666,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 // getUserOperations returns the users of AWS that must be added, deleted, updated and are equals
 func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*aws.User, delete []*aws.User, update []*aws.User, equals []*aws.User) {
 
+	log.Debug('getUserOperations()')
 	awsMap := make(map[string]*aws.User)
 	googleMap := make(map[string]struct{})
 
@@ -710,6 +712,7 @@ func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*
 // groupUsersOperations returns the groups and its users of AWS that must be delete from these groups and what are equals
 func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUsers map[string][]*aws.User) (delete map[string][]*aws.User, equals map[string][]*aws.User) {
 
+ 	log.Debug('getGroupUsersOperations()')
 	mbG := make(map[string]map[string]struct{})
 
 	// get user in google groups that are in aws groups and

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -352,7 +352,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			&identitystore.DeleteUserInput{IdentityStoreId: &s.cfg.IdentityStoreID, UserId: &awsUserFull.ID},
 		)
 		if err != nil {
-			log.Error("error deleting user")
+			log.WithField("user", awsUser).Error("error deleting user")
 			return err
 		}
 	}
@@ -377,7 +377,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			awsUser.Username,
 			awsUser.Active))
 		if err != nil {
-			log.Error("error updating user")
+		 	log.WithField("user", awsUser).Error("error updating user")
 			return err
 		}
 	}
@@ -396,7 +396,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 				log.WithField("user", awsUser.Username).Warn("user already exists")
 				continue
 			}
-			log.Error("error creating user")
+			log.WithField("user", awsUser).Error("error creating user")
 			return err
 		}
 	}

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -629,7 +629,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
 // getGroupOperations returns the groups of AWS that must be added, deleted and are equals
 func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (add []*aws.Group, delete []*aws.Group, equals []*aws.Group) {
 
- 	log.Debug('getGroupOperations()')
+ 	log.Debug("getGroupOperations()")
 	awsMap := make(map[string]*aws.Group)
 	googleMap := make(map[string]struct{})
 
@@ -666,7 +666,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 // getUserOperations returns the users of AWS that must be added, deleted, updated and are equals
 func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*aws.User, delete []*aws.User, update []*aws.User, equals []*aws.User) {
 
-	log.Debug('getUserOperations()')
+	log.Debug("getUserOperations()")
 	awsMap := make(map[string]*aws.User)
 	googleMap := make(map[string]struct{})
 
@@ -712,7 +712,7 @@ func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*
 // groupUsersOperations returns the groups and its users of AWS that must be delete from these groups and what are equals
 func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUsers map[string][]*aws.User) (delete map[string][]*aws.User, equals map[string][]*aws.User) {
 
- 	log.Debug('getGroupUsersOperations()')
+ 	log.Debug("getGroupUsersOperations()")
 	mbG := make(map[string]map[string]struct{})
 
 	// get user in google groups that are in aws groups and

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -294,7 +294,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 	if err != nil {
 		return err
 	}
-	log.WithField("googleGroups", gioogleGroups).Debug("Groups to sync")
+	log.WithField("googleGroups", googleGroups).Debug("Groups to sync")
 	log.WithField("googleUsers", googleUsers).Debug("Users to sync")
 
 	log.Info("get existing aws groups")


### PR DESCRIPTION
*Issue #, if available:*
#200 

*Description of changes:*
Google directory will accept a 'zero width space' for an empty name but will not accept a 'space', conversely AWS IAM Identity Store will accept a 'space' for an empty name but not a 'zero width space'. This change replaces 'zero width space' characters with a 'space' in the name fields of users fetched from the Google directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
