### PR TITLE
Restrict Maximum Concurrency for the ssosync lambda to 1

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -534,12 +534,14 @@ Resources:
     Condition: CreateFunction
     Properties:
       FunctionName: !If [SetFunctionName, !Ref FunctionName, !Ref AWS::NoValue]
+      Description: "An instance of ssosync deplyed from the Serverless Application Repository, for details see http://https://github.com/awslabs/ssosync"
       Role: !If [RemoteSecrets, !GetAtt SSOSyncRoleRemote.Arn, !GetAtt SSOSyncRoleLocal.Arn]
       Runtime: provided.al2
       Handler: bootstrap
       Architectures:
         - arm64
       Timeout: !Ref TimeOut
+      ReservedConcurrentExecutions: 1
       Environment:
         Variables:
           LOG_LEVEL: !Ref LogLevel


### PR DESCRIPTION
*Issue #, if available:*
#206

*Description of changes:*
Updated the CloudFormation template to hardcode the maximum allowed concurrency for the lambda function to 1. There is no situation under which it would be safe to run more than one instance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
