### PR TITLE
Fix token length which now appears to be above 600

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -155,7 +155,7 @@ Parameters:
     Description: |
       AWS IAM Identity Center - SCIM AccessToken
     Default: ""
-    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z/=+-\\]{500,600})'
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z/=+-\\]{500,620})'
     NoEcho: true
 
   Region:


### PR DESCRIPTION
*Issue #, if available:*

#211 

*Description of changes:*

Adjust SCIMEndpointAccessToken regex to allow more than 600 characters (raised to 620) as a freshly generated token by the AWS console is 603 characters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
