### PR TITLE
fix inaccurate comments

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -642,7 +642,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 		googleMap[gGroup.Name] = struct{}{}
 	}
 
-	// AWS Groups found and not found in google
+	// Google Groups found and not found in AWS
 	for _, gGroup := range googleGroups {
 		if _, found := awsMap[gGroup.Name]; found {	
 		 	log.WithField("gGroup", gGroup).Debug("equals")
@@ -653,7 +653,7 @@ func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (ad
 		}
 	}
 
-	// Google Groups founds and not in aws
+	// AWS Groups not found in Google
 	for _, awsGroup := range awsGroups {
 		if _, found := googleMap[awsGroup.DisplayName]; !found {
 		 	log.WithField("awsGroup", awsGroup).Debug("delete")


### PR DESCRIPTION
# Fix inaccurate comments in getGroupOperations function

## Purpose
This pull request addresses inaccurate comments in the `getGroupOperations` function. The existing comments do not correctly describe the function's behavior, which could lead to misunderstandings and potential bugs in future development.

## Changes
- Corrected internal comments to properly reflect the operations being performed