### PR TITLE
SCIM url regex

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -148,7 +148,7 @@ Parameters:
     Description: |
       AWS IAM Identity Center - SCIM Endpoint Url
     Default: ""
-    AllowedPattern: '(?!.*\s)|(https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/)'
+    AllowedPattern: '(?!.*\s)|(https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/?)'
 
   SCIMEndpointAccessToken:
     Type: String


### PR DESCRIPTION
webUi now provides the url without the trailing '/' making this optional for backward and forward compatibility.

*Issue #, if available:*
#222 

*Description of changes:*
Updated the scim endpoint regex, since the change in webUi now on longer has a trailing '/' on the url provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
