### PR TITLE
Allow using a pre-authenticated google access token

### DIFF
--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -17,9 +17,14 @@ package google
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"strings"
+	"time"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
@@ -43,8 +48,63 @@ const (
 	MaxRetries = 5
 )
 
+// loadAccessTokenFile reads an oauth2 token from disk. The file must contain
+// JSON like { "access_token": "...", "expiry": "RFC3339-timestamp" }. Both
+// fields are required: a missing or malformed expiry is rejected so a
+// short-lived token can't masquerade as a long-lived one. An already-expired
+// token is also rejected up front since oauth2.StaticTokenSource does not
+// refresh.
+func loadAccessTokenFile(path string, now time.Time) (*oauth2.Token, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token file: %w", err)
+	}
+	var tokenData struct {
+		AccessToken string `json:"access_token"`
+		Expiry      string `json:"expiry"`
+	}
+	if err := json.Unmarshal(data, &tokenData); err != nil {
+		return nil, fmt.Errorf("failed to parse token file: %w", err)
+	}
+	if tokenData.AccessToken == "" {
+		return nil, errors.New("token file: access_token is empty")
+	}
+	if tokenData.Expiry == "" {
+		return nil, errors.New("token file: expiry is required")
+	}
+	expiry, err := time.Parse(time.RFC3339, tokenData.Expiry)
+	if err != nil {
+		return nil, fmt.Errorf("token file: expiry is not RFC3339: %w", err)
+	}
+	if !expiry.After(now) {
+		return nil, fmt.Errorf("token file: token already expired at %s", expiry.Format(time.RFC3339))
+	}
+	return &oauth2.Token{
+		AccessToken: tokenData.AccessToken,
+		TokenType:   "Bearer",
+		Expiry:      expiry,
+	}, nil
+}
+
 // NewClient creates a new client for Google's Admin API
 func NewClient(ctx context.Context, adminEmail string, serviceAccountKey []byte) (Client, error) {
+	// Allow injecting an access token from a file pointed at by
+	// SSOSYNC_ACCESS_TOKEN_FILE. The token is used as-is via a
+	// non-refreshing oauth2.StaticTokenSource, so loadAccessTokenFile
+	// rejects empty / missing-expiry / already-expired tokens.
+	if tokenPath := os.Getenv("SSOSYNC_ACCESS_TOKEN_FILE"); tokenPath != "" {
+		tok, err := loadAccessTokenFile(tokenPath, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		ts := oauth2.StaticTokenSource(tok)
+		srv, err := admin.NewService(ctx, option.WithTokenSource(ts))
+		if err != nil {
+			return nil, fmt.Errorf("admin service: %w", err)
+		}
+		return &client{ctx: ctx, service: srv}, nil
+	}
+
 	config, err := google.JWTConfigFromJSON(serviceAccountKey, admin.AdminDirectoryGroupReadonlyScope,
 		admin.AdminDirectoryGroupMemberReadonlyScope,
 		admin.AdminDirectoryUserReadonlyScope)

--- a/internal/google/client_test.go
+++ b/internal/google/client_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2020, Amazon.com, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package google
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadAccessTokenFile(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+
+	write := func(name, body string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return path
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		path := write("ok.json", `{"access_token":"abc","expiry":"2026-06-02T13:00:00Z"}`)
+		tok, err := loadAccessTokenFile(path, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tok.AccessToken != "abc" {
+			t.Errorf("AccessToken=%q, want abc", tok.AccessToken)
+		}
+		if !tok.Expiry.Equal(time.Date(2026, 6, 2, 13, 0, 0, 0, time.UTC)) {
+			t.Errorf("Expiry=%v", tok.Expiry)
+		}
+	})
+
+	t.Run("missing_file", func(t *testing.T) {
+		_, err := loadAccessTokenFile(filepath.Join(dir, "does-not-exist.json"), now)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("malformed_json", func(t *testing.T) {
+		path := write("bad.json", `{not json`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error for malformed json")
+		}
+	})
+
+	t.Run("empty_access_token", func(t *testing.T) {
+		path := write("empty.json", `{"access_token":"","expiry":"2026-06-02T13:00:00Z"}`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error for empty access_token")
+		}
+	})
+
+	t.Run("missing_expiry", func(t *testing.T) {
+		path := write("noexp.json", `{"access_token":"abc"}`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error for missing expiry")
+		}
+	})
+
+	t.Run("malformed_expiry", func(t *testing.T) {
+		path := write("badexp.json", `{"access_token":"abc","expiry":"yesterday"}`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error for malformed expiry")
+		}
+	})
+
+	t.Run("already_expired", func(t *testing.T) {
+		path := write("expired.json", `{"access_token":"abc","expiry":"2026-06-02T11:00:00Z"}`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error for already-expired token")
+		}
+	})
+
+	t.Run("expiry_equal_to_now", func(t *testing.T) {
+		// not strictly in the future — should be rejected
+		path := write("equal.json", `{"access_token":"abc","expiry":"2026-06-02T12:00:00Z"}`)
+		if _, err := loadAccessTokenFile(path, now); err == nil {
+			t.Fatal("expected error when expiry == now")
+		}
+	})
+}
+


### PR DESCRIPTION
*Description of changes:*
Enable using a custom Google client that reuses a pre-authenticated Access Token, thus skipping the complexity of trying to use `ssosync` with WIF and other methods of authentication and allows to do all of that externally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
