### PR TITLE
not all envars must be secrets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -275,12 +276,23 @@ func configLambda() {
 
 }
 
-func getSecretFromCache(secretName string) string {
-	value, err := secretCache.GetSecretString(secretName)
-	if err != nil {
-		log.Fatal(errors.Wrap(err, fmt.Sprintf("cannot read secret: %s", secretName)).Error())
+// secretsManagerARN matches Secrets Manager ARNs across all AWS partitions
+// (aws, aws-us-gov, aws-cn, and any future partition GovCloud-style suffix).
+var secretsManagerARN = regexp.MustCompile(`^arn:aws[a-z0-9-]*:secretsmanager:`)
+
+// getSecretFromCache resolves a value that may be a Secrets Manager secret ARN
+// to its underlying secret string. Plain values (anything that is not a
+// secretsmanager ARN) are returned unchanged so callers can pass either a
+// literal value or an ARN reference through the same env var.
+func getSecretFromCache(value string) string {
+	if !secretsManagerARN.MatchString(value) {
+		return value
 	}
-	return value
+	resolved, err := secretCache.GetSecretString(value)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, fmt.Sprintf("cannot read secret: %s", value)).Error())
+	}
+	return resolved
 }
 
 func addFlags(_ *cobra.Command, cfg *config.Config) {


### PR DESCRIPTION
*Description of changes:*

Allow plaintext values for selected environment variables

Update the `configLambda()` function to support _non-secret (plaintext)_ values for selected environment variables. Previously, variables like `GOOGLE_ADMIN`, `GOOGLE_CREDENTIALS`, `REGION`, and `IDENTITY_STORE_ID` were _always_ assumed to reference AWS Secrets Manager ARNs.

With this change:
- If the environment variable _starts with_ `arn:aws:secretsmanager:`, the existing secrets manager lookup is used.
- Otherwise, the value is used **as-is**, enabling easier local development and simpler deployments that don’t require Secrets Manager.

- Introduced `maybeSecret()` helper to conditionally unwrap secrets.
- Applied it to `GOOGLE_ADMIN`, `GOOGLE_CREDENTIALS`, `SCIM_ENDPOINT`, `REGION`, and `IDENTITY_STORE_ID`.

Previously:
```env
GOOGLE_ADMIN=arn:aws:secretsmanager:...
```

Now allowed:
```env
GOOGLE_ADMIN=admin@mydomain.com
```

- [x] Existing secret-based behavior is preserved for backward compatibility.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
