### PR TITLE
Allow custom workspace customer id

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,6 +161,7 @@ func initConfig() {
 
 	appEnvVars := []string{
 		"google_admin",
+		"customer_id",
 		"google_credentials",
 		"scim_access_token",
 		"scim_endpoint",
@@ -254,6 +255,9 @@ func configLambda() {
 
 	// Get sensitive values from Secrets Manager with caching
 	cfg.GoogleAdmin = getSecretFromCache(getEnvStr("GOOGLE_ADMIN", config.DefaultGoogleCredentials))
+	// Customer ID is not a secret; read it directly so the lambda doesn't
+	// try to resolve the literal default ("my_customer") as a secret name.
+	cfg.CustomerID = getEnvStr("CUSTOMER_ID", config.DefaultCustomerID)
 	cfg.SCIMEndpoint = getSecretFromCache(getEnvStr("SCIM_ENDPOINT", ""))
 	cfg.IdentityStoreID = getSecretFromCache(getEnvStr("IDENTITY_STORE_ID", ""))
 	cfg.Region = getSecretFromCache(getEnvStr("REGION", ""))
@@ -294,6 +298,7 @@ func addFlags(_ *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringVarP(&cfg.SCIMEndpoint, "endpoint", "e", "", "AWS SSO SCIM API Endpoint")
 	rootCmd.Flags().StringVarP(&cfg.GoogleCredentials, "google-credentials", "c", config.DefaultGoogleCredentials, "path to Google Workspace credentials file")
 	rootCmd.Flags().StringVarP(&cfg.GoogleAdmin, "google-admin", "u", "", "Google Workspace admin user email")
+	rootCmd.Flags().StringVar(&cfg.CustomerID, "customer-id", config.DefaultCustomerID, "Google Workspace customer ID to operate against (defaults to 'my_customer')")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreUsers, "ignore-users", nil, "ignores these Google Workspace users")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreGroups, "ignore-groups", nil, "ignores these Google Workspace groups")
 	rootCmd.Flags().StringSliceVar(&cfg.IncludeGroups, "include-groups", nil, "include only these Google Workspace groups, NOTE: only works when --sync-method 'users_groups'")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,10 @@ type Config struct {
 	GoogleCredentials string `mapstructure:"google_credentials"`
 	// GoogleAdmin ...
 	GoogleAdmin string `mapstructure:"google_admin"`
+	// CustomerID is the Google Workspace customer ID to operate against.
+	// Defaults to "my_customer", which means the customer associated with
+	// the service account's domain.
+	CustomerID string `mapstructure:"customer_id"`
 	// UserMatch ...
 	UserMatch string `mapstructure:"user_match"`
 	// GroupFilter ...
@@ -58,6 +62,8 @@ const (
 	DefaultDebug = false
 	// DefaultGoogleCredentials is the default credentials path
 	DefaultGoogleCredentials = "credentials.json"
+	// DefaultCustomerID is the default Google Workspace customer ID.
+	DefaultCustomerID = "my_customer"
 	// DefaultSyncMethod is the default sync method to use.
 	DefaultSyncMethod = "groups"
 )
@@ -70,6 +76,7 @@ func New() *Config {
 		LogFormat:         DefaultLogFormat,
 		SyncMethod:        DefaultSyncMethod,
 		GoogleCredentials: DefaultGoogleCredentials,
+		CustomerID:        DefaultCustomerID,
 	}
 }
 

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -34,8 +34,9 @@ type Client interface {
 }
 
 type client struct {
-	ctx     context.Context
-	service *admin.Service
+	ctx        context.Context
+	service    *admin.Service
+	customerID string
 }
 
 const (
@@ -43,8 +44,11 @@ const (
 	MaxRetries = 5
 )
 
-// NewClient creates a new client for Google's Admin API
-func NewClient(ctx context.Context, adminEmail string, serviceAccountKey []byte) (Client, error) {
+// NewClient creates a new client for Google's Admin API. customerID is the
+// Google Workspace customer to operate against; pass "my_customer" (or the
+// DefaultCustomerID constant) to target the customer associated with the
+// service account's domain.
+func NewClient(ctx context.Context, adminEmail, customerID string, serviceAccountKey []byte) (Client, error) {
 	config, err := google.JWTConfigFromJSON(serviceAccountKey, admin.AdminDirectoryGroupReadonlyScope,
 		admin.AdminDirectoryGroupMemberReadonlyScope,
 		admin.AdminDirectoryUserReadonlyScope)
@@ -63,8 +67,9 @@ func NewClient(ctx context.Context, adminEmail string, serviceAccountKey []byte)
 	}
 
 	return &client{
-		ctx:     ctx,
-		service: srv,
+		ctx:        ctx,
+		service:    srv,
+		customerID: customerID,
 	}, nil
 }
 
@@ -86,7 +91,7 @@ func (c *client) getDeletedUsers() ([]*admin.User, error) {
 	u := make([]*admin.User, 0)
 	var err error
 
-	if err = c.service.Users.List().Customer("my_customer").ShowDeleted("true").Pages(c.ctx, func(users *admin.Users) error {
+	if err = c.service.Users.List().Customer(c.customerID).ShowDeleted("true").Pages(c.ctx, func(users *admin.Users) error {
 		u = append(u, users.Users...)
 		return nil
 	}); err != nil {
@@ -162,7 +167,7 @@ func (c *client) getUsers(query string, filter string) ([]*admin.User, error) {
 
 	// If we have wildcard then fetch all users
 	if query == "*" {
-		if err = c.service.Users.List().Query(filter).Customer("my_customer").Pages(c.ctx, func(users *admin.Users) error {
+		if err = c.service.Users.List().Query(filter).Customer(c.customerID).Pages(c.ctx, func(users *admin.Users) error {
 			u = append(u, users.Users...)
 			return nil
 		}); err != nil {
@@ -176,7 +181,7 @@ func (c *client) getUsers(query string, filter string) ([]*admin.User, error) {
 
 		// Then call the api one query at a time, appending to our list
 		for _, subQuery := range queries {
-			if err = c.service.Users.List().Query(subQuery+filter).Customer("my_customer").Pages(c.ctx, func(users *admin.Users) error {
+			if err = c.service.Users.List().Query(subQuery+filter).Customer(c.customerID).Pages(c.ctx, func(users *admin.Users) error {
 				u = append(u, users.Users...)
 				return nil
 			}); err != nil {
@@ -237,7 +242,7 @@ func (c *client) getGroups(query string) ([]*admin.Group, error) {
 
 	// If we have wildcard then fetch all groups
 	if query == "*" {
-		if err = c.service.Groups.List().Customer("my_customer").Pages(context.TODO(), func(groups *admin.Groups) error {
+		if err = c.service.Groups.List().Customer(c.customerID).Pages(context.TODO(), func(groups *admin.Groups) error {
 			g = append(g, groups.Groups...)
 			return nil
 		}); err != nil {
@@ -255,7 +260,7 @@ func (c *client) getGroups(query string) ([]*admin.Group, error) {
 
 	// Then call the api one query at a time, appending to our list
 	for _, subQuery := range queries {
-		if err = c.service.Groups.List().Customer("my_customer").Query(subQuery).Pages(context.TODO(), func(groups *admin.Groups) error {
+		if err = c.service.Groups.List().Customer(c.customerID).Query(subQuery).Pages(context.TODO(), func(groups *admin.Groups) error {
 			g = append(g, groups.Groups...)
 			return nil
 		}); err != nil {

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -1036,7 +1036,7 @@ func DoSync(ctx context.Context, cfg *config.Config) error {
 
 	httpClient := retryClient.StandardClient()
 
-	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, creds)
+	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, cfg.CustomerID, creds)
 	if err != nil {
 		log.WithField("error", err).Warn("Problem establising a connection to Google directory")
 		return err


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/ssosync/issues/192
https://github.com/awslabs/ssosync/pull/202

*Description of changes:*
Implement an argument and environment variable to provide a custom `customer_id` as optional additional flag. Without removing the `google-admin` one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
