### PR TITLE
Add configuration options: RAM allocation (default to 128MB), Precaching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -282,6 +282,11 @@ func configLambda() {
 	   log.WithField("IncludeGroups", unwrap).Debug("from EnvVar")
         }
 
+        unwrap = os.Getenv("PRECACHE_QUERIES")
+        if len([]rune(unwrap)) != 0 {
+           cfg.PrecacheQueries = unwrap
+           log.WithField("PrecacheQueries", unwrap).Debug("from EnvVar")
+        }
 }
 
 func addFlags(cmd *cobra.Command, cfg *config.Config) {
@@ -301,6 +306,7 @@ func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringVarP(&cfg.SyncMethod, "sync-method", "s", config.DefaultSyncMethod, "Sync method to use (users_groups|groups)")
 	rootCmd.Flags().StringVarP(&cfg.Region, "region", "r", "", "AWS Region where AWS SSO is enabled")
 	rootCmd.Flags().StringVarP(&cfg.IdentityStoreID, "identity-store-id", "i", "", "Identifier of Identity Store in AWS SSO")
+	rootCmd.Flags().StringVarP(&cfg.PrecacheQueries, "precache-queries", "p", config.DefaultPrecacheQueries, "Google Workspace Users filter queries parameter, example: 'OrgUnitPath=/', to precache all users within that Org Unit Path. For query syntax and more examples see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users")
 }
 
 func logConfig(cfg *config.Config) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -306,7 +306,7 @@ func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringVarP(&cfg.SyncMethod, "sync-method", "s", config.DefaultSyncMethod, "Sync method to use (users_groups|groups)")
 	rootCmd.Flags().StringVarP(&cfg.Region, "region", "r", "", "AWS Region where AWS SSO is enabled")
 	rootCmd.Flags().StringVarP(&cfg.IdentityStoreID, "identity-store-id", "i", "", "Identifier of Identity Store in AWS SSO")
-	rootCmd.Flags().StringVarP(&cfg.PrecacheQueries, "precache-queries", "p", config.DefaultPrecacheQueries, "Google Workspace Users filter queries parameter, example: 'OrgUnitPath=/', to precache all users within that Org Unit Path. For query syntax and more examples see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users")
+	rootCmd.Flags().StringVarP(&cfg.PrecacheQueries, "precache-queries", "p", config.DefaultPrecacheQueries, "Google Workspace Users filter queries parameter, example: 'OrgUnitPath=/ isSuspend=false isArchived=false', to precache all users within that Org Unit Path. For query syntax and more examples see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users. To disable and use caching on the fly, 'DISABLED'.")
 }
 
 func logConfig(cfg *config.Config) {

--- a/go.mod
+++ b/go.mod
@@ -1,26 +1,51 @@
 module github.com/awslabs/ssosync
 
-go 1.16
+go 1.17
 
 require (
 	github.com/BurntSushi/toml v1.0.0
 	github.com/aws/aws-lambda-go v1.23.0
 	github.com/aws/aws-sdk-go v1.44.102
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/mock v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
-	github.com/pelletier/go-toml v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/afero v1.6.0 // indirect
-	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
 	google.golang.org/api v0.46.0
+)
+
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pelletier/go-toml v1.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab // indirect
+	google.golang.org/grpc v1.37.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,7 @@ const (
 	// DefaultSyncMethod is the default sync method to use.
 	DefaultSyncMethod = "groups"
 	// DefaultPrecacheQueries
-	DefaultPrecacheQueries = "OrgUnitPath=/"
+	DefaultPrecacheQueries = "OrgUnitPath=/ isSuspend=false isArchived=false"
 )
 
 // New returns a new Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,7 @@ const (
 	// DefaultSyncMethod is the default sync method to use.
 	DefaultSyncMethod = "groups"
 	// DefaultPrecacheQueries
-	DefaultPrecacheQueries = "OrgUnitPath=/ isSuspend=false isArchived=false"
+	DefaultPrecacheQueries = "OrgUnitPath=/ isSuspended=false isArchived=false"
 )
 
 // New returns a new Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	Region string `mapstructure:"region"`
 	// IdentityStoreID is the ID of the identity store
 	IdentityStoreID string `mapstructure:"identity_store_id"`
+	// Precaching queries as a comma separated list of query strings
+	PrecacheQueries string
 }
 
 const (
@@ -50,6 +52,8 @@ const (
 	DefaultGoogleCredentials = "credentials.json"
 	// DefaultSyncMethod is the default sync method to use.
 	DefaultSyncMethod = "groups"
+	// DefaultPrecacheQueries
+	DefaultPrecacheQueries = "OrgUnitPath=/"
 )
 
 // New returns a new Config
@@ -60,5 +64,6 @@ func New() *Config {
 		LogFormat:         DefaultLogFormat,
 		SyncMethod:        DefaultSyncMethod,
 		GoogleCredentials: DefaultGoogleCredentials,
+		PrecacheQueries: DefaultPrecacheQueries,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,5 @@ func New() *Config {
 		LogFormat:         DefaultLogFormat,
 		SyncMethod:        DefaultSyncMethod,
 		GoogleCredentials: DefaultGoogleCredentials,
-		PrecacheQueries: DefaultPrecacheQueries,
 	}
 }

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -153,10 +153,6 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 		user.Name.FamilyName = strings.Replace(user.Name.FamilyName, string('\u200B'), " ", -1)
 	}
 
-	// Check we've got some users otherwise something is wrong.
-	if len(u) == 0 {
-		return u, errors.New("google api returned 0 users?")
-	}
 	return u, err
 
 }

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -577,6 +577,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
         	      		log.WithField("email", u).Debug("processing member of gUserDetailCache")
                 		gUserDetailCache[u.PrimaryEmail] = u
         		}
+		}
 	} else {
 		log.Info("Precaching DISABLED, caching on the fly")
 	}

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -563,7 +563,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
         // For larger directories this will reduce execution time and avoid throttling limits
         // however if you have directory with 10s of 1000s of users you may want to down scope 
         // this to a specific OU path or disable by leaving empty.
-        if len(s.cfg.PrecacheQueries) > 0 {
+        if s.cfg.PrecacheQueries != "DISABLED" {
  		log.Info("Precaching users from google, for the following querie strings '" + s.cfg.PrecacheQueries + "'.") 
         	googleUsers, err = s.google.GetUsers(s.cfg.PrecacheQueries) 
         	if err != nil {

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -564,7 +564,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
         // however if you have directory with 10s of 1000s of users you may want to down scope 
         // this to a specific OU path or disable by leaving empty.
         if len(s.cfg.PrecacheQueries) > 0 {
- 		log.Debug("Precaching users from google, with the OrgUnitPath of '" + s.cfg.PrecacheQueries + "'to use as cache") 
+ 		log.Info("Precaching users from google, for the following querie strings '" + s.cfg.PrecacheQueries + "'.") 
         	googleUsers, err = s.google.GetUsers(s.cfg.PrecacheQueries) 
         	if err != nil {
         	        return nil, nil, nil, err
@@ -573,6 +573,8 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
         	      	log.WithField("email", u).Debug("processing member of gUserDetailCache")
                 	gUserDetailCache[u.PrimaryEmail] = u
         	}
+	} else {
+		log.Info("Precaching disabled, caching on the fly")
 	}
 
 	log.Debug("get groups from google")

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -566,15 +566,19 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
         if s.cfg.PrecacheQueries != "DISABLED" {
  		log.Info("Precaching users from google, for the following querie strings '" + s.cfg.PrecacheQueries + "'.") 
         	googleUsers, err = s.google.GetUsers(s.cfg.PrecacheQueries) 
-        	if err != nil {
-        	        return nil, nil, nil, err
-        	}
-        	for _, u := range googleUsers {
-        	      	log.WithField("email", u).Debug("processing member of gUserDetailCache")
-                	gUserDetailCache[u.PrimaryEmail] = u
-        	}
+		if err != nil {
+                        return nil, nil, nil, err
+                }
+
+		if len(googleUsers) == 0 {
+			log.Warn("Precaching failed, caching on the fly")
+		} else {
+        		for _, u := range googleUsers {
+        	      		log.WithField("email", u).Debug("processing member of gUserDetailCache")
+                		gUserDetailCache[u.PrimaryEmail] = u
+        		}
 	} else {
-		log.Info("Precaching disabled, caching on the fly")
+		log.Info("Precaching DISABLED, caching on the fly")
 	}
 
 	log.Debug("get groups from google")

--- a/template.yaml
+++ b/template.yaml
@@ -117,7 +117,15 @@ Parameters:
     AllowedValues:
       - json
       - text
-        
+
+  MemorySize:
+    Type: Number
+    Description: |
+      [required] the amount of RAM allocated to the function, within range 128-10240MB. default is 128MB.
+    Default: 128
+    MinValue: 128
+    MaxValue: 10240
+     
   TimeOut:
     Type: Number
     Description: |
@@ -540,6 +548,7 @@ Resources:
       Handler: bootstrap
       Architectures:
         - arm64
+      MemorySize: !Ref MemorySize
       Timeout: !Ref TimeOut
       ReservedConcurrentExecutions: 1
       Environment:

--- a/template.yaml
+++ b/template.yaml
@@ -449,15 +449,16 @@ Resources:
               - Sid: IdentityStoreAccesPolicy
                 Effect: Allow
                 Action:
-                  - "identitystore:List*"
-                  - "identitystore:Describe*"
-                  - "identitystore:IsMemberInGroups"
-                  - "identitystore:GetGroupMembershipId"
+                  - "identitystore:DeleteUser"
                   - "identitystore:CreateGroup"
                   - "identitystore:CreateGroupMembership"
+                  - "identitystore:ListGroups"
+                  - "identitystore:ListUsers"
+                  - "identitystore:ListGroupMemberships"
+                  - "identitystore:IsMemberInGroups"
+                  - "identitystore:GetGroupMembershipId"
                   - "identitystore:DeleteGroupMembership"
                   - "identitystore:DeleteGroup"
-                  - "identitystore:DeleteUser"
                 Resource:
                   - "*"
               - Sid: CodePipelinePolicy


### PR DESCRIPTION
*Issue #, if available:*
#248 

*Description of changes:*
Add template option to configure the RAM allocation for the lambda function, retains default of 128MB.

Allows Precaching queries to be customized from the full directory scope,
Specify _OrgUnitPath_ if User is not found in the precache then its added on the fly
Precaching can be disabled entirely by specifying **DISABLED**
If an invalid query is supplied sync will continue but as though precaching was disabled



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
