### PR TITLE
Add handling for an email alias for a user

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -1433,13 +1433,15 @@ func (s *syncGSuite) getGoogleUsersInGroup(group *admin.Group, userCache map[str
 			}
 			// Add user to the cache
 			for _, u := range googleUsers {
-				log.WithFields(log.Fields{
-					"func":    funcName,
-					"GroupId": group.Id,
-					"Member#": memberIndex,
-				}).Debug("Cache user")
+				if _, found := userCache[u.PrimaryEmail]; !found {
+					log.WithFields(log.Fields{
+						"func":    funcName,
+						"GroupId": group.Id,
+						"Member#": memberIndex,
+					}).Debug("Cache user")
+					userCache[u.PrimaryEmail] = u
+				}
 				memberEmail = u.PrimaryEmail
-				userCache[memberEmail] = u
 			}
 			// Check whether the member was based on an alias
 			if memberEmail != m.Email {


### PR DESCRIPTION
*Issue #, if available:*
#275

*Description of changes:*
Where a user has been added as a member within a group by virtue of an ALIAS (email alias), then it needs to be de-referenced to use the users primary email address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
