### PR TITLE
docs: Rename SCIM flags to endpoint and access-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ SSO Sync requires configuration from both Google Workspace and AWS sides.
 ./ssosync \
   --google-admin admin@company.com \
   --google-credentials ./credentials.json \
-  --scim-endpoint https://scim.us-east-1.amazonaws.com/... \
-  --scim-access-token AQoDYXdzE... \
+  --endpoint https://scim.us-east-1.amazonaws.com/... \
+  --access-token AQoDYXdzE... \
   --region us-east-1 \
   --identity-store-id d-1234567890 \
   --group-match "name:AWS*"
@@ -212,8 +212,8 @@ export SSOSYNC_DRY_RUN="true"
 |------|---------------------|-------------|---------|
 | `--google-admin` | `SSOSYNC_GOOGLE_ADMIN` | Google Workspace admin email | Required |
 | `--google-credentials` | `SSOSYNC_GOOGLE_CREDENTIALS` | Path to Google credentials JSON | `credentials.json` |
-| `--scim-endpoint` | `SSOSYNC_SCIM_ENDPOINT` | AWS SCIM endpoint URL | Required |
-| `--scim-access-token` | `SSOSYNC_SCIM_ACCESS_TOKEN` | AWS SCIM access token | Required |
+| `--endpoint` | `SSOSYNC_SCIM_ENDPOINT` | AWS SCIM endpoint URL | Required |
+| `--access-token` | `SSOSYNC_SCIM_ACCESS_TOKEN` | AWS SCIM access token | Required |
 | `--region` | `SSOSYNC_REGION` | AWS region | Required |
 | `--identity-store-id` | `SSOSYNC_IDENTITY_STORE_ID` | AWS Identity Store ID | Required |
 | `--sync-method` | `SSOSYNC_SYNC_METHOD` | Sync method (`groups` or `users_groups`) | `groups` |


### PR DESCRIPTION
*TL;DR*

* updates readme usage flags to be in sync with implementation.

*Description of changes:*

Having gone through the readme, and running the example I noticed the flags were out of sync with the actual implementation.

```
FATA[0000] unknown flag: --scim-endpoint
```

Refer implementation here: https://github.com/awslabs/ssosync/blob/8aeb6d1f606db20bf80261b879f5cdd73a777615/cmd/root.go#L289-L290


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
