### PR TITLE
fix: use group email instead of name for sync comparison in SyncGroupsUsers

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -823,7 +823,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
 			"group.Id": g.Id,
 			"gMembers": gMembers,
 		}).Debug("Finished group membership")
-		gGroupsUsers[g.Name] = gMembers
+		gGroupsUsers[g.Email] = gMembers
 	}
 
 	log.WithField("func", funcName).Debug("create gUsers")
@@ -847,17 +847,17 @@ func getGroupOperations(awsGroups []*interfaces.Group, googleGroups []*admin.Gro
 	}
 
 	for _, gGroup := range googleGroups {
-		googleMap[gGroup.Name] = struct{}{}
+		googleMap[gGroup.Email] = struct{}{}
 	}
 
 	// Google Groups found and not found in AWS
 	for _, gGroup := range googleGroups {
-		if _, found := awsMap[gGroup.Name]; found {
+		if _, found := awsMap[gGroup.Email]; found {
 			log.WithField("gGroup", gGroup).Debug("equals")
-			equals = append(equals, awsMap[gGroup.Name])
+			equals = append(equals, awsMap[gGroup.Email])
 		} else {
 			log.WithField("gGroup", gGroup).Debug("add")
-			add = append(add, aws.NewGroup(gGroup.Name))
+			add = append(add, aws.NewGroup(gGroup.Email))
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a bug where groups were being deleted and recreated on every sync cycle when using the `SyncGroupsUsers` (default `groups`) sync method.

## Problem

When the sync runs, groups are incorrectly identified as "not existing" and get deleted then recreated. This happens because of an identifier mismatch:

| Location | Identifier Used | Example |
|----------|----------------|---------|
| `SyncGroups` / `CreateGroup` | `g.Email` | `aws-admins@company.com` |
| `SyncGroupsUsers` / `getGroupOperations` | `g.Name` | `AWS Admins` |

Since AWS Identity Store groups are created with the email as `DisplayName`, but comparisons in `getGroupOperations` used the group's display name (`g.Name`), the sync logic incorrectly concluded:
1. AWS group (keyed by email) → "not in Google" → **delete**
2. Google group (keyed by name) → "not in AWS" → **create**

## Evidence from CloudTrail

```
10:05:23 - DeleteGroup
10:06:14 - CreateGroup  
10:06:14 - CreateGroupMembership (x2)
```

This pattern repeated every sync cycle, causing group permission assignments to be disrupted.

## Fix

Changed three locations in `internal/sync.go`:

1. **Line 826** (`getGoogleGroupsAndUsers`):
   ```diff
   - gGroupsUsers[g.Name] = gMembers
   + gGroupsUsers[g.Email] = gMembers
   ```

2. **Lines 850-860** (`getGroupOperations`):
   ```diff
   - googleMap[gGroup.Name] = struct{}{}
   + googleMap[gGroup.Email] = struct{}{}
   
   - if _, found := awsMap[gGroup.Name]; found {
   + if _, found := awsMap[gGroup.Email]; found {
       // ...
   -   equals = append(equals, awsMap[gGroup.Name])
   +   equals = append(equals, awsMap[gGroup.Email])
     } else {
   -   add = append(add, aws.NewGroup(gGroup.Name))
   +   add = append(add, aws.NewGroup(gGroup.Email))
     }
   ```

## Testing

- Verified groups are no longer deleted/recreated on sync
- Confirmed membership operations work correctly