### PR TITLE
fix: use group email instead of name for sync comparison in SyncGroupsUsers

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -823,7 +823,7 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers stri
 			"group.Id": g.Id,
 			"gMembers": gMembers,
 		}).Debug("Finished group membership")
-		gGroupsUsers[g.Name] = gMembers
+		gGroupsUsers[g.Email] = gMembers
 	}
 
 	log.WithField("func", funcName).Debug("create gUsers")
@@ -847,17 +847,17 @@ func getGroupOperations(awsGroups []*interfaces.Group, googleGroups []*admin.Gro
 	}
 
 	for _, gGroup := range googleGroups {
-		googleMap[gGroup.Name] = struct{}{}
+		googleMap[gGroup.Email] = struct{}{}
 	}
 
 	// Google Groups found and not found in AWS
 	for _, gGroup := range googleGroups {
-		if _, found := awsMap[gGroup.Name]; found {
+		if _, found := awsMap[gGroup.Email]; found {
 			log.WithField("gGroup", gGroup).Debug("equals")
-			equals = append(equals, awsMap[gGroup.Name])
+			equals = append(equals, awsMap[gGroup.Email])
 		} else {
 			log.WithField("gGroup", gGroup).Debug("add")
-			add = append(add, aws.NewGroup(gGroup.Name))
+			add = append(add, aws.NewGroup(gGroup.Email))
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the default `groups` sync method where groups can be deleted and recreated when membership changes occur (e.g., when a user is added to a Google Group).

## Problem

The `getGroupOperations` function compares Google groups with AWS groups to determine which groups need to be added, deleted, or are equal. However, there was an identifier mismatch:

- **AWS groups** have `DisplayName` set to the group's **email** (e.g., `aws-admins@company.com`)
- **Google groups** were being keyed/compared using `g.Name` (the display name, e.g., `AWS Admins`)

This caused `getGroupOperations` to incorrectly conclude:
1. The AWS group (keyed by email) was "not found in Google" → marked for **deletion**
2. The Google group (keyed by name) was "not found in AWS" → marked for **creation**

### Observed Behavior (from CloudTrail)
```
DeleteGroup   @ 10:05:23
CreateGroup   @ 10:06:14
CreateGroupMembership (x2) @ 10:06:14
```

This results in:
- Group being deleted and recreated unnecessarily
- Loss of the group's AWS Identity Store ID
- Any permission set assignments referencing the old group ID become orphaned

## Root Cause

In `getGoogleGroupsAndUsers` (line 826):
```go
gGroupsUsers[g.Name] = gMembers  // Using Name as key
```

In `getGroupOperations` (lines 850-860):
```go
googleMap[gGroup.Name] = struct{}{}           // Using Name
if _, found := awsMap[gGroup.Name]; found {   // Comparing with Name
    equals = append(equals, awsMap[gGroup.Name])
} else {
    add = append(add, aws.NewGroup(gGroup.Name))  // Creating with Name
}
```

But AWS groups are created with `g.Email` as the DisplayName (in `SyncGroupsUsers` line 412-417), so the comparison fails.

## Fix

Changed to use `g.Email` consistently to match how groups are stored in AWS Identity Store:

```diff
// getGoogleGroupsAndUsers (line 826)
- gGroupsUsers[g.Name] = gMembers
+ gGroupsUsers[g.Email] = gMembers

// getGroupOperations (lines 850-860)
- googleMap[gGroup.Name] = struct{}{}
+ googleMap[gGroup.Email] = struct{}{}

- if _, found := awsMap[gGroup.Name]; found {
+ if _, found := awsMap[gGroup.Email]; found {
-     equals = append(equals, awsMap[gGroup.Name])
+     equals = append(equals, awsMap[gGroup.Email])
  } else {
-     add = append(add, aws.NewGroup(gGroup.Name))
+     add = append(add, aws.NewGroup(gGroup.Email))
  }
```

## Impact

- Affects the default `groups` sync method (`SyncGroupsUsers`)
- Prevents unnecessary group deletion/recreation
- Preserves group IDs and associated permission set assignments

## Testing

- Verified groups are no longer deleted/recreated when users are added to groups
- Confirmed membership sync operations work correctly