### PR TITLE
Fix: Correct SYNC_METHOD fallback in Lambda configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -259,7 +259,7 @@ func configLambda() {
 	// Handle environment variables for other settings
 	cfg.LogLevel = getEnvStr("LOG_LEVEL", config.DefaultLogLevel)
 	cfg.LogFormat = getEnvStr("LOG_FORMAT", config.DefaultLogFormat)
-	cfg.SyncMethod = getEnvStr("SYNC_METHOD", config.DefaultLogFormat)
+	cfg.SyncMethod = getEnvStr("SYNC_METHOD", config.DefaultSyncMethod)
 	cfg.UserMatch = getEnvStr("USER_MATCH", "")
 	cfg.GroupMatch = getEnvStr("GROUP_MATCH", "*")
 	cfg.IgnoreGroups = getEnvStrs("IGNORE_GROUPS", []string{})


### PR DESCRIPTION
*Description of changes:*

Fixed a bug in the Lambda configuration where `SYNC_METHOD` environment variable was incorrectly falling back to DefaultLogFormat ("text") instead of DefaultSyncMethod ("groups").

This bug caused the default sync method to be "text" instead of "groups", which resulted in the sync process incorrectly executing the users_groups workflow (calling `SyncUsers()` followed by `SyncGroups()`) instead of the intended default groups workflow (calling `SyncGroupsUsers()`).

The sync method selection logic in `internal/sync.go` checks `if cfg.SyncMethod == config.DefaultSyncMethod ("groups")`. When the fallback was incorrectly set to "text", this condition would always be false, causing the else branch (users_groups method) to execute by default.

Changed:
- Fixed the fallback value from `config.DefaultLogFormat` to `config.DefaultSyncMethod`

Impact:

- Lambda deployments will now correctly default to the groups sync method as intended
- The `SyncGroupsUsers()` method will be used by default instead of the sequential `SyncUsers()` + `SyncGroups()` approach

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
