### PR TITLE
Feat: Delete users if inactive only

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -90,7 +90,36 @@ func (s *syncGSuite) SyncUsers(query string) error {
 		return err
 	}
 
-	for _, u := range deletedUsers {
+	activeGoogleUsers, err := s.google.GetUsers(query)
+	if err != nil {
+		return err
+	}
+
+	var newDeletedUsers = make([]*admin.User, 0)
+	var isDeletedUserActive = false
+	for _, deleteUser := range deletedUsers {
+		isDeletedUserActive = false
+		log.WithFields(log.Fields{
+			"email": deleteUser.PrimaryEmail,
+		}).Debug("Inspecting deleted user email")
+		for _, activeGoogleUser := range activeGoogleUsers {
+			if deleteUser.PrimaryEmail == activeGoogleUser.PrimaryEmail {
+				isDeletedUserActive = true
+				log.WithFields(log.Fields{
+				    "email": deleteUser.PrimaryEmail,
+				}).Debug("User is active again! Breaking loop...")
+				break
+			}
+		}
+		if !isDeletedUserActive {
+			log.WithFields(log.Fields{
+				"email": deleteUser.PrimaryEmail,
+			}).Debug("Inactive user email")
+			newDeletedUsers = append(newDeletedUsers, deleteUser)
+		}
+	}
+
+	for _, u := range newDeletedUsers {
 		log.WithFields(log.Fields{
 			"email": u.PrimaryEmail,
 		}).Info("deleting google user")

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -90,7 +90,7 @@ func (s *syncGSuite) SyncUsers(query string) error {
 		return err
 	}
 
-	activeGoogleUsers, err := s.google.GetUsers(query)
+	activeGoogleUsers, err := s.google.GetUsers(query, s.cfg.UserFilter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #59*

*Description of changes:*

**Problem**
Noticed that if we delete a user on the Google side and then recreate it with the exact same details the following occurs:
1) ssosync will consider that user as inactive based on the API response, hence deleting it from AWS SSO
https://github.com/awslabs/ssosync/blob/master/internal/sync.go#L70-L103
https://github.com/awslabs/ssosync/blob/master/internal/google/client.go#L64-L73

2) ssosync will then list all the active users and it will see that it needs to add again the user that has just been deleted in the previous step.
https://github.com/awslabs/ssosync/blob/master/internal/sync.go#L105-L152

3) At this stage user will have no permission sets assigned on AWS SSO, and this will happen every time we run ssosync.

**Possible Solution**
I believe that it would be beneficial to change the `SyncUsers` function so it checks that all of the API returned deleted users are in fact inactive, and for the ones that are now active it just ignores them by building a new list of deleted users which we can iterate over just like its being done atm.