### PR TITLE
329 v25x updates every user and group on every run externalid is never read back from the identity store

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -367,19 +367,21 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 	}
 
 	// create list of changes by operations
-	addAWSUsers, delAWSUsers, updateAWSUsers, _ := getUserOperations(awsUsers, googleUsers)
+	addAWSUsers, delAWSUsers, updateAWSUsers, unchangedAWSUsers := getUserOperations(awsUsers, googleUsers)
 	log.WithFields(
 		log.Fields{
-			"addUsers": len(addAWSUsers),
-			"updateUsers": len(updateAWSUsers),
-			"delUsers": len(delAWSUsers)}).Info("syncing user changes")
+			"unchanged": len(unchangedAWSUsers),
+			"create": len(addAWSUsers),
+			"update": len(updateAWSUsers),
+			"delete": len(delAWSUsers)}).Info("syncing user changes")
 
-	addAWSGroups, delAWSGroups, updateAWSGroups, equalAWSGroups := getGroupOperations(awsGroups, googleGroups)
+	addAWSGroups, delAWSGroups, updateAWSGroups, unchangedAWSGroups := getGroupOperations(awsGroups, googleGroups)
 	log.WithFields(
 		log.Fields{
-			"addUsers": len(addAWSGroups),
-			"updateUsers": len(updateAWSGroups),
-			"delUsers": len(delAWSGroups)}).Info("syncing group changes")
+			"unchanged": len(unchangedAWSGroups),
+			"create": len(addAWSGroups),
+			"update": len(updateAWSGroups),
+			"delete": len(delAWSGroups)}).Info("syncing group changes")
 
 	// update aws users (updated in google)
 	log.Debug("updating aws users updated in google")
@@ -493,7 +495,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 
 	// validate groups members are equal in aws and google
 	log.Debug("validating groups members, equals in aws and google")
-	for _, awsGroup := range equalAWSGroups {
+	for _, awsGroup := range unchangedAWSGroups {
 
 		// add members of the new group
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -373,7 +373,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			"unchanged": len(unchangedAWSUsers),
 			"create": len(addAWSUsers),
 			"update": len(updateAWSUsers),
-			"delete": len(delAWSUsers)}).Info("syncing user changes")
+			"delete": len(delAWSUsers)}).Info("Change Summary: users")
 
 	addAWSGroups, delAWSGroups, updateAWSGroups, unchangedAWSGroups := getGroupOperations(awsGroups, googleGroups)
 	log.WithFields(
@@ -381,7 +381,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			"unchanged": len(unchangedAWSGroups),
 			"create": len(addAWSGroups),
 			"update": len(updateAWSGroups),
-			"delete": len(delAWSGroups)}).Info("syncing group changes")
+			"delete": len(delAWSGroups)}).Info("Change Summary: Groups")
 
 	// update aws users (updated in google)
 	log.Debug("updating aws users updated in google")

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -1270,8 +1270,9 @@ func ConvertSdkUserObjToNative(user identitystore_types.User) *interfaces.User {
 	}
 
 	return &interfaces.User{
-		ID:       *user.UserId,
-		Schemas:  []string{constants.SCIMSchemaUser},
+		ID:         *user.UserId,
+		ExternalId: getExternalId(user.ExternalIds),
+		Schemas:    []string{constants.SCIMSchemaUser},
 		Username: *user.UserName,
 		Name: struct {
 			FamilyName string `json:"familyName"`
@@ -1284,6 +1285,15 @@ func ConvertSdkUserObjToNative(user identitystore_types.User) *interfaces.User {
 		Emails:      userEmails,
 		Addresses:   userAddresses,
 	}
+}
+
+// getExternalId extracts the external ID from the identity store ExternalIds slice.
+// Returns an empty string if no external IDs are present.
+func getExternalId(externalIds []identitystore_types.ExternalId) string {
+	if len(externalIds) > 0 && externalIds[0].Id != nil {
+		return *externalIds[0].Id
+	}
+	return ""
 }
 
 // CreateUserIDtoUserObjMap

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -368,9 +368,18 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 
 	// create list of changes by operations
 	addAWSUsers, delAWSUsers, updateAWSUsers, _ := getUserOperations(awsUsers, googleUsers)
-	addAWSGroups, delAWSGroups, updateAWSGroups, equalAWSGroups := getGroupOperations(awsGroups, googleGroups)
+	log.WithFields(
+		log.Fields{
+			"addUsers": len(addAWSUsers),
+			"updateUsers": len(updateAWSUsers),
+			"delUsers": len(delAWSUsers)}).Info("syncing user changes")
 
-	log.Info("syncing changes")
+	addAWSGroups, delAWSGroups, updateAWSGroups, equalAWSGroups := getGroupOperations(awsGroups, googleGroups)
+	log.WithFields(
+		log.Fields{
+			"addUsers": len(addAWSGroups),
+			"updateUsers": len(updateAWSGroups),
+			"delUsers": len(delAWSGroups)}).Info("syncing group changes")
 
 	// update aws users (updated in google)
 	log.Debug("updating aws users updated in google")

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -1195,6 +1195,7 @@ func ConvertIdentityStoreGroupToAWSGroup(group identitystore_types.Group) *inter
 	log.WithField("groupId", group.GroupId).WithField("displayName", group.DisplayName).Debug("ConvertIdentityStoreGroupToAWSGroup() Group converted")
 	return &interfaces.Group{
 		ID:          *group.GroupId,
+		ExternalId:  getExternalId(group.ExternalIds),
 		Schemas:     []string{constants.SCIMSchemaGroup},
 		DisplayName: *group.DisplayName,
 		Members:     []string{},


### PR DESCRIPTION
*Issue #, if available:*
#329 

*Description of changes:*
- Updated to pull ExternalId for Users and Groups from IdentityStore before comparison.
- Added summary of changes to aid monitoring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
