### PR TITLE
fix: log group id/displayName values instead of pointers in ConvertIdentityStoreGroupToAWSGroup

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -1320,7 +1320,7 @@ func ConvertIdentityStoreGroupToAWSGroup(group identitystore_types.Group) *inter
 		log.WithField("group", group).Warn("ConvertIdentityStoreGroupToAWSGroup() Group has no DisplayName")
 		return nil
 	}
-	log.WithField("groupId", group.GroupId).WithField("displayName", group.DisplayName).Debug("ConvertIdentityStoreGroupToAWSGroup() Group converted")
+	log.WithField("groupId", *group.GroupId).WithField("displayName", *group.DisplayName).Debug("ConvertIdentityStoreGroupToAWSGroup() Group converted")
 	return &interfaces.Group{
 		ID:          *group.GroupId,
 		ExternalId:  getExternalId(group.ExternalIds),


### PR DESCRIPTION
## Description

`ConvertIdentityStoreGroupToAWSGroup` logged `group.GroupId` and `group.DisplayName` (both `*string`) directly, so the `Group converted` debug line printed pointer addresses (e.g. `displayName=0x1400010f810 groupId=0x1400010f7f0`) instead of the values. This dereferences them. Both are nil-checked immediately above the log call, so it is safe.

Fixes #335

## Testing

- `go build ./...` passes.
- Ran ssosync with `--debug` against IAM Identity Center; the `ConvertIdentityStoreGroupToAWSGroup() Group converted` debug lines now show real values (e.g. `displayName=engineering groupId=9067...`) instead of `0x...` pointers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.