### PR TITLE
Fix DRY_RUN aborting on users that do not exist yet

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -358,15 +358,25 @@ func (s *syncGSuite) SyncGroups(query string) error {
 
 		for _, u := range s.users {
 			log.WithField("user", u.Username).Debug("Checking user is in group already")
-			b, err := identitystore.IsMemberInGroups(context.Background(), s.identityStore, &s.cfg.IdentityStoreID, []string{group.ID}, &u.ID)
-			if err != nil {
-				return err
+
+			// Dry-run users have no ID; the Identity Store rejects an empty
+			// memberId.userId, and a user that does not exist is not a member.
+			var b *bool
+			if u.ID == "" {
+				notAMember := false
+				b = &notAMember
+			} else {
+				var err error
+				b, err = identitystore.IsMemberInGroups(context.Background(), s.identityStore, &s.cfg.IdentityStoreID, []string{group.ID}, &u.ID)
+				if err != nil {
+					return err
+				}
 			}
 
 			if _, ok := memberList[u.Username]; ok {
 				if !*b {
 					log.WithField("user", u.Username).Info("Adding user to group")
-					err = s.aws.AddUserToGroup(u, group)
+					err := s.aws.AddUserToGroup(u, group)
 					if err != nil {
 						return err
 					}

--- a/internal/sync_test.go
+++ b/internal/sync_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	admin "google.golang.org/api/admin/directory/v1"
 )
 
@@ -653,4 +654,42 @@ func TestDoSync_DryRun(t *testing.T) {
 	err := DoSync(context.Background(), cfg)
 	// We expect this to fail without proper credentials, but we're testing the dry run path
 	assert.Error(t, err) // Expected to fail without valid credentials
+}
+
+func TestSyncGroups_DryRunUserWithoutID(t *testing.T) {
+	cfg := &config.Config{
+		SyncMethod:      "users_groups",
+		IncludeGroups:   []string{"group@example.com"},
+		IdentityStoreID: "d-1234567890",
+		DryRun:          true,
+	}
+
+	group := &admin.Group{Email: "group@example.com", Id: "gid"}
+	awsGroup := &interfaces.Group{ID: "aws-gid", DisplayName: "group@example.com"}
+
+	googleClient := mocks.NewMockGoogleClient(t)
+	googleClient.EXPECT().GetGroups("").Return([]*admin.Group{group}, nil)
+	googleClient.EXPECT().GetGroupMembers(group).
+		Return([]*admin.Member{{Email: "new@example.com"}}, nil)
+
+	awsClient := mocks.NewMockAwsClient(t)
+	awsClient.EXPECT().FindGroupByDisplayName("group@example.com").Return(awsGroup, nil)
+	awsClient.EXPECT().AddUserToGroup(mock.Anything, awsGroup).Return(nil)
+
+	// No EXPECT for IsMemberInGroups: mockery fails the test on any unexpected
+	// call, so this asserts the API is never reached for an ID-less user.
+	identityStore := mocks.NewMockIdentityStoreAPI(t)
+
+	s := &syncGSuite{
+		aws:           awsClient,
+		google:        googleClient,
+		identityStore: identityStore,
+		cfg:           cfg,
+		users: map[string]*interfaces.User{
+			// As dryClient.CreateUser leaves it: no ID.
+			"new@example.com": {Username: "new@example.com", ID: ""},
+		},
+	}
+
+	assert.NoError(t, s.SyncGroups(""))
 }


### PR DESCRIPTION
dryClient.CreateUser returns the user unchanged, so a user only pretended into
existence still has an empty ID. SyncGroups passed that ID straight to
IsMemberInGroups, which rejects it:

    ValidationException: Value '' at 'memberId.userId' failed to satisfy
    constraint: Member must have length greater than or equal to 1

The sync then died on the first group containing such a user, before evaluating
a single membership change. That makes DRY_RUN unusable whenever the Google
directory holds anyone Identity Center does not -- the normal state before an
initial sync, and precisely when a dry run is worth doing.

A user that does not exist cannot be a member of anything, so answer locally
instead of calling the API. Additions are still reported, so the dry-run output
stays complete.

Fixes #281.

#313 fixes the same failure more broadly: virtual IDs minted in the dry-run
shims, covering UpdateUser and ListGroupMemberships too, without touching shared
code. This change is deliberately minimal instead: one guard at the call site
that fails. The tradeoff is that it sits in SyncGroups rather than in the
dry-run shims, so it is on the path both sync methods run. Maintainers may
prefer #313's approach; happy to close this in its favour.