### PR TITLE
Fix sync deadlock when a Google user's primary email is renamed

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -473,25 +473,19 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			"delete": len(delAWSGroups)}).Info("Change Summary: Groups")
 
 	// update aws users (updated in google)
+	// The entries in updateAWSUsers already carry the identity store ID and
+	// the desired attributes, so update directly. Re-finding the user by
+	// email here deadlocks the sync when the update is a primary-email
+	// rename: the query uses the new address while SCIM still holds the old
+	// one, so no user is found and every run aborts before its first write
+	// (#353).
 	log.Debug("updating aws users updated in google")
 	for _, awsUser := range updateAWSUsers {
 
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
 
-		log.Debug("finding user")
-		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
-		if err != nil {
-			return err
-		}
-
 		log.Warn("updating user")
-		_, err = s.aws.UpdateUser(aws.UpdateUser(
-			awsUserFull.ID,
-			awsUser.Name.GivenName,
-			awsUser.Name.FamilyName,
-			awsUser.Username,
-			awsUser.Active,
-			awsUser.ExternalId))
+		_, err := s.aws.UpdateUser(awsUser)
 		if err != nil {
 			log.WithField("user", awsUser).Error("error updating user")
 			return err
@@ -537,6 +531,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			log.WithField("email:", googleUser.PrimaryEmail).Debug("aws.FindUserByEmail() finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
+				log.WithField("email", googleUser.PrimaryEmail).Error("user not found in identity store")
 				return err
 			}
 
@@ -568,6 +563,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			log.WithField("email:", googleUser.PrimaryEmail).Debug("aws.FindUserByEmail() finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
+				log.WithField("email", googleUser.PrimaryEmail).Error("user not found in identity store")
 				return err
 			}
 
@@ -642,6 +638,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 		log.Debug("finding user")
 		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
 		if err != nil {
+			log.Error("user not found in identity store")
 			return err
 		}
 
@@ -1122,6 +1119,7 @@ func (s *syncGSuite) getGroupUsersOperations(gGroupsUsers map[string][]*admin.Us
 				log.Debug("finding user")
 				awsUserFull, err := s.aws.FindUserByEmail(gUser.PrimaryEmail)
 				if err != nil {
+					log.WithField("email", gUser.PrimaryEmail).Error("user not found in identity store")
 					return nil, nil, nil, err
 				}
 				add[gGroupName] = append(add[gGroupName], awsUserFull)


### PR DESCRIPTION
Fixes #353.

**What breaks:** when a user's primary email is renamed in Google Workspace, `getUserOperations` matches them by ExternalId and builds the update entry with the new address. The update loop in `SyncGroupsUsers` then re-finds the user with `FindUserByEmail(new address)`, but SCIM still holds the old userName, so the lookup returns `user not found` and the run aborts before its first write. The mismatch the update would have repaired is never written, so every run from then on dies the same way until the identity store is edited by hand. At the default `warn` log level the only output is the final fatal, which is how this ran unnoticed in our org for two and a half days.

**The fix:** the entries in `updateAWSUsers` are built by `aws.UpdateUser(awsUser.ID, ...)` and already carry the identity store ID and every attribute to write, so the loop now updates directly from the entry. The email re-lookup was redundant even when it succeeded: it re-found the same user only to read back the ID the entry already had.

**Also:** the remaining `FindUserByEmail` call sites in the group-member loops, the delete loop, and `getGroupUsersOperations` returned bare errors; they now log the affected email address at error level before aborting, so the next data-shaped failure names its record instead of dying silently.

No test currently exercises `SyncGroupsUsers`; happy to add one for the update path if you can point me at the preferred harness for it.