### PR TITLE
353 changing a users primary email in google workspace permanently aborts every sync

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -480,7 +480,7 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 
 		log.Warn("updating user")
 		_, err = s.aws.UpdateUser(aws.UpdateUser(
-			awsUserFull.ID,
+			awsUser.ID,
 			awsUser.Name.GivenName,
 			awsUser.Name.FamilyName,
 			awsUser.Username,

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -478,12 +478,6 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
 
-		log.Debug("finding user")
-		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
-		if err != nil {
-			return err
-		}
-
 		log.Warn("updating user")
 		_, err = s.aws.UpdateUser(aws.UpdateUser(
 			awsUserFull.ID,


### PR DESCRIPTION
*Issue #, if available:*
#353 

*Description of changes:*
Bug fix for unexpected error when user's primary email address is updated, in Google Workspace directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
